### PR TITLE
Review recent changes

### DIFF
--- a/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
@@ -2,12 +2,17 @@ package com.medistock.data.dao
 
 import androidx.room.*
 import com.medistock.data.entities.Category
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CategoryDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(category: Category): Long
+    fun insertBlocking(category: Category): Long
+
+    suspend fun insert(category: Category): Long {
+        return insertBlocking(category)
+    }
 
     @Update
     suspend fun update(category: Category)
@@ -16,7 +21,7 @@ interface CategoryDao {
     suspend fun delete(category: Category)
 
     @Query("SELECT * FROM categories")
-    suspend fun getAll(): List<Category>
+    fun getAll(): Flow<List<Category>>
 
     @Query("SELECT * FROM categories WHERE id = :categoryId LIMIT 1")
     suspend fun getById(categoryId: Long): Category?

--- a/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
@@ -2,11 +2,16 @@ package com.medistock.data.dao
 
 import androidx.room.*
 import com.medistock.data.entities.Inventory
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface InventoryDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(inventory: Inventory): Long
+    fun insertBlocking(inventory: Inventory): Long
+
+    suspend fun insert(inventory: Inventory): Long {
+        return insertBlocking(inventory)
+    }
 
     @Update
     suspend fun update(inventory: Inventory)
@@ -15,13 +20,13 @@ interface InventoryDao {
     suspend fun getById(inventoryId: Long): Inventory?
 
     @Query("SELECT * FROM inventories WHERE productId = :productId AND siteId = :siteId ORDER BY countDate DESC")
-    suspend fun getInventoriesForProduct(productId: Long, siteId: Long): List<Inventory>
+    fun getInventoriesForProduct(productId: Long, siteId: Long): Flow<List<Inventory>>
 
     @Query("SELECT * FROM inventories WHERE siteId = :siteId ORDER BY countDate DESC")
-    suspend fun getInventoriesForSite(siteId: Long): List<Inventory>
+    fun getInventoriesForSite(siteId: Long): Flow<List<Inventory>>
 
     @Query("SELECT * FROM inventories ORDER BY countDate DESC LIMIT :limit")
-    suspend fun getRecentInventories(limit: Int = 50): List<Inventory>
+    fun getRecentInventories(limit: Int = 50): Flow<List<Inventory>>
 
     /**
      * Get inventories with discrepancies (difference != 0).
@@ -32,7 +37,7 @@ interface InventoryDao {
         AND discrepancy != 0
         ORDER BY countDate DESC
     """)
-    suspend fun getInventoriesWithDiscrepancies(siteId: Long): List<Inventory>
+    fun getInventoriesWithDiscrepancies(siteId: Long): Flow<List<Inventory>>
 
     /**
      * Get total discrepancy value for a site.

--- a/app/src/main/java/com/medistock/data/dao/ProductPriceDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductPriceDao.kt
@@ -3,14 +3,19 @@ package com.medistock.data.dao
 import androidx.room.*
 import com.medistock.data.entities.ProductPrice
 import com.medistock.data.entities.ProductSale
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ProductPriceDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(price: ProductPrice): Long
+    fun insertBlocking(price: ProductPrice): Long
+
+    suspend fun insert(price: ProductPrice): Long {
+        return insertBlocking(price)
+    }
 
     @Query("SELECT * FROM product_prices")
-    suspend fun getAll(): List<ProductPrice>
+    fun getAll(): Flow<List<ProductPrice>>
 
     @Query("SELECT * FROM product_prices WHERE productId = :productId ORDER BY effectiveDate DESC LIMIT 1")
     suspend fun getLatestPrice(productId: Long): ProductPrice?

--- a/app/src/main/java/com/medistock/data/dao/ProductSaleDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductSaleDao.kt
@@ -3,18 +3,23 @@ package com.medistock.data.dao
 import androidx.room.*
 import com.medistock.data.entities.ProductSale
 import com.medistock.data.entities.StockMovement
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ProductSaleDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(sale: ProductSale): Long
+    fun insertBlocking(sale: ProductSale): Long
+
+    suspend fun insert(sale: ProductSale): Long {
+        return insertBlocking(sale)
+    }
 
     @Query("SELECT * FROM product_sales")
-    suspend fun getAll(): List<ProductSale>
+    fun getAll(): Flow<List<ProductSale>>
 
     @Query("SELECT * FROM product_sales WHERE productId = :productId AND siteId = :siteId ORDER BY date DESC")
-    suspend fun getSalesForProduct(productId: Long, siteId: Long): List<ProductSale>
+    fun getSalesForProduct(productId: Long, siteId: Long): Flow<List<ProductSale>>
 
     @Query("SELECT * FROM product_sales WHERE siteId = :siteId ORDER BY date DESC")
-    suspend fun getAllForSite(siteId: Long): List<ProductSale>
+    fun getAllForSite(siteId: Long): Flow<List<ProductSale>>
 }

--- a/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
@@ -2,11 +2,16 @@ package com.medistock.data.dao
 
 import androidx.room.*
 import com.medistock.data.entities.PurchaseBatch
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface PurchaseBatchDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(batch: PurchaseBatch): Long
+    fun insertBlocking(batch: PurchaseBatch): Long
+
+    suspend fun insert(batch: PurchaseBatch): Long {
+        return insertBlocking(batch)
+    }
 
     @Update
     suspend fun update(batch: PurchaseBatch)
@@ -15,7 +20,7 @@ interface PurchaseBatchDao {
     suspend fun getById(batchId: Long): PurchaseBatch?
 
     @Query("SELECT * FROM purchase_batches WHERE productId = :productId AND siteId = :siteId ORDER BY purchaseDate ASC")
-    suspend fun getBatchesForProduct(productId: Long, siteId: Long): List<PurchaseBatch>
+    fun getBatchesForProduct(productId: Long, siteId: Long): Flow<List<PurchaseBatch>>
 
     /**
      * Get available batches (not exhausted) for FIFO consumption.
@@ -29,7 +34,7 @@ interface PurchaseBatchDao {
         AND remainingQuantity > 0
         ORDER BY purchaseDate ASC
     """)
-    suspend fun getAvailableBatchesFIFO(productId: Long, siteId: Long): List<PurchaseBatch>
+    fun getAvailableBatchesFIFO(productId: Long, siteId: Long): Flow<List<PurchaseBatch>>
 
     /**
      * Get batches expiring soon (within days threshold).
@@ -43,7 +48,7 @@ interface PurchaseBatchDao {
         AND expiryDate <= :thresholdDate
         ORDER BY expiryDate ASC
     """)
-    suspend fun getBatchesExpiringSoon(productId: Long, siteId: Long, thresholdDate: Long): List<PurchaseBatch>
+    fun getBatchesExpiringSoon(productId: Long, siteId: Long, thresholdDate: Long): Flow<List<PurchaseBatch>>
 
     /**
      * Calculate average purchase price for a product.

--- a/app/src/main/java/com/medistock/data/dao/SiteDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/SiteDao.kt
@@ -2,12 +2,17 @@ package com.medistock.data.dao
 
 import androidx.room.*
 import com.medistock.data.entities.Site
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface SiteDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(site: Site): Long
+    fun insertBlocking(site: Site): Long
+
+    suspend fun insert(site: Site): Long {
+        return insertBlocking(site)
+    }
 
     @Query("SELECT * FROM sites")
-    suspend fun getAll(): List<Site>
+    fun getAll(): Flow<List<Site>>
 }

--- a/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
@@ -3,20 +3,25 @@ package com.medistock.data.dao
 import androidx.room.*
 import com.medistock.data.entities.CurrentStock
 import com.medistock.data.entities.StockMovement
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface StockMovementDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(movement: StockMovement): Long
+    fun insertBlocking(movement: StockMovement): Long
+
+    suspend fun insert(movement: StockMovement): Long {
+        return insertBlocking(movement)
+    }
 
     @Query("SELECT * FROM stock_movements")
-    suspend fun getAll(): List<StockMovement>
+    fun getAll(): Flow<List<StockMovement>>
 
     @Query("SELECT * FROM stock_movements WHERE productId = :productId AND siteId = :siteId ORDER BY date DESC")
-    suspend fun getMovementsForProduct(productId: Long, siteId: Long): List<StockMovement>
+    fun getMovementsForProduct(productId: Long, siteId: Long): Flow<List<StockMovement>>
 
     @Query("SELECT * FROM stock_movements WHERE siteId = :siteId")
-    suspend fun getAllForSite(siteId: Long): List<StockMovement>
+    fun getAllForSite(siteId: Long): Flow<List<StockMovement>>
 
     /**
      * Calculate current stock for all products at a specific site.
@@ -45,7 +50,7 @@ interface StockMovementDao {
         GROUP BY p.id, s.id
         ORDER BY p.name
     """)
-    suspend fun getCurrentStockForSite(siteId: Long): List<CurrentStock>
+    fun getCurrentStockForSite(siteId: Long): Flow<List<CurrentStock>>
 
     /**
      * Calculate current stock for all products across all sites.
@@ -72,7 +77,7 @@ interface StockMovementDao {
         GROUP BY p.id, s.id
         ORDER BY s.name, p.name
     """)
-    suspend fun getCurrentStockAllSites(): List<CurrentStock>
+    fun getCurrentStockAllSites(): Flow<List<CurrentStock>>
 
     /**
      * Calculate total stock for a specific product across all sites.


### PR DESCRIPTION
Applied the same pattern used in ProductDao to all other DAOs:
- CategoryDao: Convert getAll() to return Flow<List<Category>>
- ProductPriceDao: Convert getAll() to return Flow
- ProductSaleDao: Convert list queries to return Flow
- SiteDao: Convert getAll() to return Flow
- InventoryDao: Convert list queries to return Flow
- PurchaseBatchDao: Convert list queries to return Flow
- StockMovementDao: Convert list and stock queries to return Flow

All insert methods now use insertBlocking() pattern with suspend wrapper. This resolves the "Not sure how to convert a Cursor to this method's return type" Room compilation error.