### PR TITLE
Fix: Convert single-object query methods to Flow to resolve Room comp…

### DIFF
--- a/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
@@ -24,5 +24,5 @@ interface CategoryDao {
     fun getAll(): Flow<List<Category>>
 
     @Query("SELECT * FROM categories WHERE id = :categoryId LIMIT 1")
-    suspend fun getById(categoryId: Long): Category?
+    fun getById(categoryId: Long): Flow<Category?>
 }

--- a/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
@@ -17,7 +17,7 @@ interface InventoryDao {
     suspend fun update(inventory: Inventory)
 
     @Query("SELECT * FROM inventories WHERE id = :inventoryId")
-    suspend fun getById(inventoryId: Long): Inventory?
+    fun getById(inventoryId: Long): Flow<Inventory?>
 
     @Query("SELECT * FROM inventories WHERE productId = :productId AND siteId = :siteId ORDER BY countDate DESC")
     fun getInventoriesForProduct(productId: Long, siteId: Long): Flow<List<Inventory>>
@@ -47,7 +47,7 @@ interface InventoryDao {
         WHERE siteId = :siteId
         AND countDate >= :startDate
     """)
-    suspend fun getTotalDiscrepancy(siteId: Long, startDate: Long): Double?
+    fun getTotalDiscrepancy(siteId: Long, startDate: Long): Double?
 
     @Query("DELETE FROM inventories WHERE id = :inventoryId")
     suspend fun deleteById(inventoryId: Long)

--- a/app/src/main/java/com/medistock/data/dao/ProductPriceDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductPriceDao.kt
@@ -18,5 +18,5 @@ interface ProductPriceDao {
     fun getAll(): Flow<List<ProductPrice>>
 
     @Query("SELECT * FROM product_prices WHERE productId = :productId ORDER BY effectiveDate DESC LIMIT 1")
-    suspend fun getLatestPrice(productId: Long): ProductPrice?
+    fun getLatestPrice(productId: Long): Flow<ProductPrice?>
 }

--- a/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
@@ -17,7 +17,7 @@ interface PurchaseBatchDao {
     suspend fun update(batch: PurchaseBatch)
 
     @Query("SELECT * FROM purchase_batches WHERE id = :batchId")
-    suspend fun getById(batchId: Long): PurchaseBatch?
+    fun getById(batchId: Long): Flow<PurchaseBatch?>
 
     @Query("SELECT * FROM purchase_batches WHERE productId = :productId AND siteId = :siteId ORDER BY purchaseDate ASC")
     fun getBatchesForProduct(productId: Long, siteId: Long): Flow<List<PurchaseBatch>>
@@ -59,7 +59,7 @@ interface PurchaseBatchDao {
         AND siteId = :siteId
         AND isExhausted = 0
     """)
-    suspend fun getAveragePurchasePrice(productId: Long, siteId: Long): Double?
+    fun getAveragePurchasePrice(productId: Long, siteId: Long): Double?
 
     /**
      * Get total remaining quantity across all batches.
@@ -70,7 +70,7 @@ interface PurchaseBatchDao {
         AND siteId = :siteId
         AND isExhausted = 0
     """)
-    suspend fun getTotalRemainingQuantity(productId: Long, siteId: Long): Double?
+    fun getTotalRemainingQuantity(productId: Long, siteId: Long): Double?
 
     @Query("DELETE FROM purchase_batches WHERE id = :batchId")
     suspend fun deleteById(batchId: Long)

--- a/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
@@ -101,5 +101,5 @@ interface StockMovementDao {
         WHERE p.id = :productId
         GROUP BY p.id
     """)
-    suspend fun getTotalStockForProduct(productId: Long): CurrentStock?
+    fun getTotalStockForProduct(productId: Long): Flow<CurrentStock?>
 }


### PR DESCRIPTION
…ilation errors

Fixed remaining Room compilation errors by converting all single-object queries from suspend functions to Flow:

Changed to Flow:
- CategoryDao.getById(): Category? → Flow<Category?>
- ProductPriceDao.getLatestPrice(): ProductPrice? → Flow<ProductPrice?>
- InventoryDao.getById(): Inventory? → Flow<Inventory?>
- PurchaseBatchDao.getById(): PurchaseBatch? → Flow<PurchaseBatch?>
- StockMovementDao.getTotalStockForProduct(): CurrentStock? → Flow<CurrentStock?>

Changed to synchronous (removed suspend):
- InventoryDao.getTotalDiscrepancy(): Double?
- PurchaseBatchDao.getAveragePurchasePrice(): Double?
- PurchaseBatchDao.getTotalRemainingQuantity(): Double?

This resolves the "Not sure how to convert a Cursor to this method's return type" error for all remaining DAO methods. Room requires either Flow or synchronous functions for @Query methods that return single objects or scalar values.