### PR TITLE
Fix: Remove suspend from @Update and @Delete methods to resolve Room …

### DIFF
--- a/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
@@ -15,10 +15,10 @@ interface CategoryDao {
     }
 
     @Update
-    suspend fun update(category: Category)
+    fun update(category: Category)
 
     @Delete
-    suspend fun delete(category: Category)
+    fun delete(category: Category)
 
     @Query("SELECT * FROM categories")
     fun getAll(): Flow<List<Category>>

--- a/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
@@ -14,7 +14,7 @@ interface InventoryDao {
     }
 
     @Update
-    suspend fun update(inventory: Inventory)
+    fun update(inventory: Inventory)
 
     @Query("SELECT * FROM inventories WHERE id = :inventoryId")
     fun getById(inventoryId: Long): Flow<Inventory?>
@@ -50,5 +50,5 @@ interface InventoryDao {
     fun getTotalDiscrepancy(siteId: Long, startDate: Long): Double?
 
     @Query("DELETE FROM inventories WHERE id = :inventoryId")
-    suspend fun deleteById(inventoryId: Long)
+    fun deleteById(inventoryId: Long)
 }

--- a/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
@@ -14,7 +14,7 @@ interface PurchaseBatchDao {
     }
 
     @Update
-    suspend fun update(batch: PurchaseBatch)
+    fun update(batch: PurchaseBatch)
 
     @Query("SELECT * FROM purchase_batches WHERE id = :batchId")
     fun getById(batchId: Long): Flow<PurchaseBatch?>
@@ -73,5 +73,5 @@ interface PurchaseBatchDao {
     fun getTotalRemainingQuantity(productId: Long, siteId: Long): Double?
 
     @Query("DELETE FROM purchase_batches WHERE id = :batchId")
-    suspend fun deleteById(batchId: Long)
+    fun deleteById(batchId: Long)
 }


### PR DESCRIPTION
…errors

Room does not support suspend functions for @Update and @Delete operations. Changed to synchronous functions:

CategoryDao:
- @Update update(): removed suspend
- @Delete delete(): removed suspend

InventoryDao:
- @Update update(): removed suspend
- @Query deleteById(): removed suspend

PurchaseBatchDao:
- @Update update(): removed suspend
- @Query deleteById(): removed suspend

This resolves the "Not sure how to handle delete method's return type" error.