### PR TITLE
Fix: Add missing minStock and maxStock to getTotalStockForProduct query

### DIFF
--- a/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
@@ -94,7 +94,9 @@ interface StockMovementDao {
                 SUM(CASE WHEN sm.type = 'in' THEN sm.quantity ELSE 0 END) -
                 SUM(CASE WHEN sm.type = 'out' THEN sm.quantity ELSE 0 END),
                 0
-            ) as quantityOnHand
+            ) as quantityOnHand,
+            p.minStock as minStock,
+            p.maxStock as maxStock
         FROM products p
         LEFT JOIN categories c ON p.categoryId = c.id
         LEFT JOIN stock_movements sm ON sm.productId = p.id


### PR DESCRIPTION
The getTotalStockForProduct query was missing the minStock and maxStock columns that are required by the CurrentStock entity. Added these columns to the SELECT statement to resolve the Room compilation error.

Error: "The columns returned by the query does not have the fields [minStock,maxStock] in com.medistock.data.entities.CurrentStock"