### PR TITLE
Fix: Update all Activities and ViewModels to use Flow from DAO methods

### DIFF
--- a/app/src/main/java/com/medistock/ui/MainActivity.kt
+++ b/app/src/main/java/com/medistock/ui/MainActivity.kt
@@ -12,7 +12,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.room.Room
 import com.medistock.R
 import com.medistock.data.db.AppDatabase
-import com.medistock.data.entities.Product
+import com.medistock.data.entities.ProductWithCategory
 import com.medistock.ui.adapters.ProductAdapter
 import com.medistock.ui.product.ProductAddActivity
 import com.medistock.util.PrefsHelper
@@ -23,7 +23,6 @@ class MainActivity : AppCompatActivity() {
     private lateinit var db: AppDatabase
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: ProductAdapter
-    private var products: List<Product> = emptyList()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -36,14 +35,11 @@ class MainActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             val siteId = PrefsHelper.getActiveSiteId(this@MainActivity)
-            products = loadProductsForSite(siteId)
-            adapter = ProductAdapter(products)
-            recyclerView.adapter = adapter
+            db.productDao().getProductsWithCategoryForSite(siteId).collect { products ->
+                adapter = ProductAdapter(products)
+                recyclerView.adapter = adapter
+            }
         }
-    }
-
-    private suspend fun loadProductsForSite(siteId: Long): List<Product> {
-        return db.productDao().getAll().filter { it.siteId == siteId }
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/app/src/main/java/com/medistock/ui/category/CategoryAddEditActivity.kt
+++ b/app/src/main/java/com/medistock/ui/category/CategoryAddEditActivity.kt
@@ -10,6 +10,7 @@ import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.Category
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class CategoryAddEditActivity : AppCompatActivity() {
@@ -27,7 +28,7 @@ class CategoryAddEditActivity : AppCompatActivity() {
         categoryId = intent.getLongExtra("CATEGORY_ID", -1).takeIf { it != -1L }
         if (categoryId != null) {
             CoroutineScope(Dispatchers.IO).launch {
-                val cat = db.categoryDao().getById(categoryId!!)
+                val cat = db.categoryDao().getById(categoryId!!).first()
                 runOnUiThread {
                     if (cat != null) {
                         editName.setText(cat.name ?: "")

--- a/app/src/main/java/com/medistock/ui/category/CategoryListActivity.kt
+++ b/app/src/main/java/com/medistock/ui/category/CategoryListActivity.kt
@@ -11,6 +11,7 @@ import com.medistock.data.db.AppDatabase
 import com.medistock.ui.adapters.CategoryAdapter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class CategoryListActivity : AppCompatActivity() {
@@ -41,7 +42,7 @@ class CategoryListActivity : AppCompatActivity() {
 
     private fun loadCategories() {
         CoroutineScope(Dispatchers.IO).launch {
-            val categories = db.categoryDao().getAll()
+            val categories = db.categoryDao().getAll().first()
             runOnUiThread { adapter.submitList(categories) }
         }
     }

--- a/app/src/main/java/com/medistock/ui/inventory/InventoryActivity.kt
+++ b/app/src/main/java/com/medistock/ui/inventory/InventoryActivity.kt
@@ -9,6 +9,7 @@ import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.*
 import com.medistock.util.PrefsHelper
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -69,8 +70,8 @@ class InventoryActivity : AppCompatActivity() {
 
     private fun loadProducts() {
         lifecycleScope.launch(Dispatchers.IO) {
-            products = db.productDao().getAll()
-            currentStockItems = db.stockMovementDao().getCurrentStockForSite(currentSiteId)
+            products = db.productDao().getAll().first()
+            currentStockItems = db.stockMovementDao().getCurrentStockForSite(currentSiteId).first()
 
             withContext(Dispatchers.Main) {
                 val productNames = products.map { "${it.name} (${it.unit})" }
@@ -144,7 +145,7 @@ class InventoryActivity : AppCompatActivity() {
             // If there's a discrepancy, create a stock adjustment movement
             if (discrepancy != 0.0) {
                 val product = products.find { it.id == selectedProductId }
-                val latestPrice = db.productPriceDao().getLatestPrice(selectedProductId)
+                val latestPrice = db.productPriceDao().getLatestPrice(selectedProductId).first()
 
                 val movement = StockMovement(
                     productId = selectedProductId,

--- a/app/src/main/java/com/medistock/ui/movement/StockMovementActivity.kt
+++ b/app/src/main/java/com/medistock/ui/movement/StockMovementActivity.kt
@@ -8,6 +8,7 @@ import androidx.room.Room
 import com.medistock.R
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.*
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class StockMovementActivity : AppCompatActivity() {
@@ -29,7 +30,7 @@ class StockMovementActivity : AppCompatActivity() {
         typeSpinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, listOf("in", "out"))
 
         lifecycleScope.launch {
-            products = db.productDao().getAll()
+            products = db.productDao().getAll().first()
             productSpinner.adapter = ArrayAdapter(
                 this@StockMovementActivity,
                 android.R.layout.simple_spinner_item,
@@ -46,7 +47,7 @@ class StockMovementActivity : AppCompatActivity() {
                 val product = products[selectedProductIndex]
                 val quantityInBaseUnit = quantity * product.unitVolume
                 lifecycleScope.launch {
-                    val latestPrice = db.productPriceDao().getLatestPrice(product.id)
+                    val latestPrice = db.productPriceDao().getLatestPrice(product.id).first()
                     if (latestPrice != null) {
                         val siteId = com.medistock.util.PrefsHelper.getActiveSiteId(this@StockMovementActivity)
                     db.stockMovementDao().insert(

--- a/app/src/main/java/com/medistock/ui/movement/StockMovementListActivity.kt
+++ b/app/src/main/java/com/medistock/ui/movement/StockMovementListActivity.kt
@@ -10,6 +10,7 @@ import com.medistock.R
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.Product
 import com.medistock.util.PrefsHelper
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class StockMovementListActivity : AppCompatActivity() {
@@ -22,8 +23,8 @@ class StockMovementListActivity : AppCompatActivity() {
         val siteId = PrefsHelper.getActiveSiteId(this)
 
         lifecycleScope.launch {
-            val products = db.productDao().getProductsForSite(siteId).associateBy { it.id }
-            val movements = db.stockMovementDao().getAllForSite(siteId)
+            val products = db.productDao().getProductsForSite(siteId).first().associateBy { it.id }
+            val movements = db.stockMovementDao().getAllForSite(siteId).first()
             val items = movements.map {
                 val productName = products[it.productId]?.name ?: "Unknown"
                 "Product: $productName, Type: ${it.type}, Qty: ${it.quantity}, Date: ${java.util.Date(it.date)}"

--- a/app/src/main/java/com/medistock/ui/product/ProductAddActivity.kt
+++ b/app/src/main/java/com/medistock/ui/product/ProductAddActivity.kt
@@ -13,6 +13,7 @@ import com.medistock.data.entities.Category
 import com.medistock.data.entities.Product
 import com.medistock.util.PrefsHelper
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -50,7 +51,7 @@ class ProductAddActivity : AppCompatActivity() {
 
         // Charger categories depuis DB
         lifecycleScope.launch {
-            categories = db.categoryDao().getAll()
+            categories = db.categoryDao().getAll().first()
             val categoryNames = categories.map { it.name }
             val categoryAdapter = ArrayAdapter(this@ProductAddActivity, android.R.layout.simple_spinner_item, categoryNames)
             categoryAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)

--- a/app/src/main/java/com/medistock/ui/purchase/PurchaseActivity.kt
+++ b/app/src/main/java/com/medistock/ui/purchase/PurchaseActivity.kt
@@ -9,6 +9,7 @@ import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.*
 import com.medistock.util.PrefsHelper
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
@@ -94,7 +95,7 @@ class PurchaseActivity : AppCompatActivity() {
 
     private fun loadProducts() {
         lifecycleScope.launch(Dispatchers.IO) {
-            products = db.productDao().getAll()
+            products = db.productDao().getAll().first()
             withContext(Dispatchers.Main) {
                 val productNames = products.map { "${it.name} (${it.unit})" }
                 val adapter = ArrayAdapter(

--- a/app/src/main/java/com/medistock/ui/sales/SaleActivity.kt
+++ b/app/src/main/java/com/medistock/ui/sales/SaleActivity.kt
@@ -8,6 +8,7 @@ import androidx.room.Room
 import com.medistock.R
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.*
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class SaleActivity : AppCompatActivity() {
@@ -35,7 +36,7 @@ class SaleActivity : AppCompatActivity() {
         textPriceInfo = findViewById(R.id.textSalePriceInfo)
 
         lifecycleScope.launch {
-            products = db.productDao().getAll()
+            products = db.productDao().getAll().first()
             productSpinner.adapter = ArrayAdapter(
                 this@SaleActivity,
                 android.R.layout.simple_spinner_item,
@@ -92,7 +93,7 @@ class SaleActivity : AppCompatActivity() {
 
     private fun loadSuggestedPrice(productId: Long) {
         lifecycleScope.launch {
-            val latestPrice = db.productPriceDao().getLatestPrice(productId)
+            val latestPrice = db.productPriceDao().getLatestPrice(productId).first()
             if (latestPrice != null) {
                 priceInput.setText(String.format("%.2f", latestPrice.sellingPrice))
                 textPriceInfo.text = "Prix suggéré (dernier prix de vente enregistré)"

--- a/app/src/main/java/com/medistock/ui/sales/SaleListActivity.kt
+++ b/app/src/main/java/com/medistock/ui/sales/SaleListActivity.kt
@@ -9,6 +9,7 @@ import androidx.room.Room
 import com.medistock.R
 import com.medistock.data.db.AppDatabase
 import com.medistock.util.PrefsHelper
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class SaleListActivity : AppCompatActivity() {
@@ -21,8 +22,8 @@ class SaleListActivity : AppCompatActivity() {
         val siteId = PrefsHelper.getActiveSiteId(this)
 
         lifecycleScope.launch {
-            val products = db.productDao().getProductsForSite(siteId).associateBy { it.id }
-            val sales = db.productSaleDao().getAllForSite(siteId)
+            val products = db.productDao().getProductsForSite(siteId).first().associateBy { it.id }
+            val sales = db.productSaleDao().getAllForSite(siteId).first()
             val items = sales.map {
                 val productName = products[it.productId]?.name ?: "Unknown"
                 "Product: $productName, Qty: ${it.quantity}, Farmer: ${it.farmerName}, Date: ${java.util.Date(it.date)}"

--- a/app/src/main/java/com/medistock/ui/site/SiteSelectorActivity.kt
+++ b/app/src/main/java/com/medistock/ui/site/SiteSelectorActivity.kt
@@ -10,6 +10,7 @@ import com.medistock.R
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.Site
 import com.medistock.ui.MainActivity
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class SiteSelectorActivity : AppCompatActivity() {
@@ -30,7 +31,7 @@ class SiteSelectorActivity : AppCompatActivity() {
         val btnAddSite = findViewById<Button>(R.id.btnAddSite)
 
         lifecycleScope.launch {
-            sites = db.siteDao().getAll()
+            sites = db.siteDao().getAll().first()
             siteSpinner.adapter = ArrayAdapter(
                 this@SiteSelectorActivity,
                 android.R.layout.simple_spinner_item,
@@ -43,7 +44,7 @@ class SiteSelectorActivity : AppCompatActivity() {
             if (siteName.isNotEmpty()) {
                 lifecycleScope.launch {
                     db.siteDao().insert(Site(name = siteName))
-                    val refreshedSites = db.siteDao().getAll()
+                    val refreshedSites = db.siteDao().getAll().first()
                     sites = refreshedSites
                     siteSpinner.adapter = ArrayAdapter(
                         this@SiteSelectorActivity,

--- a/app/src/main/java/com/medistock/ui/stock/StockListActivity.kt
+++ b/app/src/main/java/com/medistock/ui/stock/StockListActivity.kt
@@ -16,6 +16,7 @@ import com.medistock.data.entities.CurrentStock
 import com.medistock.data.entities.Site
 import com.medistock.ui.adapters.StockAdapter
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -49,7 +50,7 @@ class StockListActivity : AppCompatActivity() {
 
     private fun loadSites() {
         lifecycleScope.launch(Dispatchers.IO) {
-            sites = db.siteDao().getAll()
+            sites = db.siteDao().getAll().first()
             withContext(Dispatchers.Main) {
                 // Add "All Sites" option
                 val siteNames = mutableListOf("Tous les sites")
@@ -85,7 +86,7 @@ class StockListActivity : AppCompatActivity() {
 
     private fun loadStockForSite(siteId: Long) {
         lifecycleScope.launch(Dispatchers.IO) {
-            currentStockItems = db.stockMovementDao().getCurrentStockForSite(siteId)
+            currentStockItems = db.stockMovementDao().getCurrentStockForSite(siteId).first()
             withContext(Dispatchers.Main) {
                 adapter.updateData(currentStockItems)
                 updateSummary()
@@ -95,7 +96,7 @@ class StockListActivity : AppCompatActivity() {
 
     private fun loadStockAllSites() {
         lifecycleScope.launch(Dispatchers.IO) {
-            currentStockItems = db.stockMovementDao().getCurrentStockAllSites()
+            currentStockItems = db.stockMovementDao().getCurrentStockAllSites().first()
             withContext(Dispatchers.Main) {
                 adapter.updateData(currentStockItems)
                 updateSummary()

--- a/app/src/main/java/com/medistock/ui/viewmodel/ProductViewModel.kt
+++ b/app/src/main/java/com/medistock/ui/viewmodel/ProductViewModel.kt
@@ -9,6 +9,7 @@ import com.medistock.data.entities.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class ProductViewModel(application: Application) : AndroidViewModel(application) {
@@ -27,13 +28,13 @@ class ProductViewModel(application: Application) : AndroidViewModel(application)
 
     private fun loadProducts() {
         viewModelScope.launch(Dispatchers.IO) {
-            _products.value = db.productDao().getAll()
+            _products.value = db.productDao().getAll().first()
         }
     }
 
     fun loadCategories() {
         viewModelScope.launch(Dispatchers.IO) {
-            _categories.value = db.categoryDao().getAll()
+            _categories.value = db.categoryDao().getAll().first()
         }
     }
 
@@ -60,7 +61,7 @@ class ProductViewModel(application: Application) : AndroidViewModel(application)
 
     fun loadProductsForSite(siteId: Long) {
         viewModelScope.launch(Dispatchers.IO) {
-            _products.value = db.productDao().getProductsForSite(siteId)
+            _products.value = db.productDao().getProductsForSite(siteId).first()
         }
     }
 }


### PR DESCRIPTION
After converting all DAO methods to return Flow instead of direct values, updated all Activity and ViewModel files to properly collect from Flow.

Changes:
- All DAO method calls now use .first() to get the first emission from Flow
- Added import for kotlinx.coroutines.flow.first where needed
- MainActivity now uses ProductWithCategory instead of Product to match adapter
- MainActivity now observes products using .collect{} for reactive updates

Files updated (13):
- MainActivity: Changed to use getProductsWithCategoryForSite() with Flow
- CategoryAddEditActivity: getById() now uses .first()
- CategoryListActivity: getAll() now uses .first()
- InventoryActivity: Multiple DAO calls updated to use .first()
- StockMovementActivity: getAll() and getLatestPrice() use .first()
- StockMovementListActivity: getAllForSite() methods use .first()
- ProductAddActivity: getAll() uses .first()
- PurchaseActivity: getAll() and getLatestPrice() use .first()
- SaleActivity: getAll() and getLatestPrice() use .first()
- SaleListActivity: getAllForSite() methods use .first()
- SiteSelectorActivity: getAll() uses .first()
- StockListActivity: Multiple stock queries use .first()
- ProductViewModel: All DAO calls updated to use .first()

All coroutine scopes were already in place (lifecycleScope.launch or viewModelScope.launch). Using .first() for one-time fetches is appropriate for these use cases where data is loaded when screens open.