### PR TITLE
Fix: Handle nullable Product fields with Elvis operator

### DIFF
--- a/app/src/main/java/com/medistock/ui/movement/StockMovementActivity.kt
+++ b/app/src/main/java/com/medistock/ui/movement/StockMovementActivity.kt
@@ -45,7 +45,7 @@ class StockMovementActivity : AppCompatActivity() {
 
             if (selectedProductIndex >= 0 && quantity != null) {
                 val product = products[selectedProductIndex]
-                val quantityInBaseUnit = quantity * product.unitVolume
+                val quantityInBaseUnit = quantity * (product.unitVolume ?: 1.0)
                 lifecycleScope.launch {
                     val latestPrice = db.productPriceDao().getLatestPrice(product.id).first()
                     if (latestPrice != null) {

--- a/app/src/main/java/com/medistock/ui/purchase/PurchaseActivity.kt
+++ b/app/src/main/java/com/medistock/ui/purchase/PurchaseActivity.kt
@@ -112,8 +112,8 @@ class PurchaseActivity : AppCompatActivity() {
     private fun updateMarginInfo() {
         val product = selectedProduct ?: return
         val marginInfo = when (product.marginType) {
-            "fixed" -> "Marge: +${product.marginValue} (fixe)"
-            "percentage" -> "Marge: +${product.marginValue}%"
+            "fixed" -> "Marge: +${product.marginValue ?: 0.0} (fixe)"
+            "percentage" -> "Marge: +${product.marginValue ?: 0.0}%"
             else -> "Pas de marge configurée"
         }
         textMarginInfo.text = marginInfo
@@ -124,8 +124,8 @@ class PurchaseActivity : AppCompatActivity() {
         val purchasePrice = editPurchasePrice.text.toString().toDoubleOrNull() ?: 0.0
 
         val calculatedSellingPrice = when (product.marginType) {
-            "fixed" -> purchasePrice + product.marginValue
-            "percentage" -> purchasePrice * (1 + product.marginValue / 100)
+            "fixed" -> purchasePrice + (product.marginValue ?: 0.0)
+            "percentage" -> purchasePrice * (1 + (product.marginValue ?: 0.0) / 100)
             else -> purchasePrice
         }
 

--- a/app/src/main/java/com/medistock/ui/viewmodel/ProductViewModel.kt
+++ b/app/src/main/java/com/medistock/ui/viewmodel/ProductViewModel.kt
@@ -42,8 +42,8 @@ class ProductViewModel(application: Application) : AndroidViewModel(application)
         viewModelScope.launch(Dispatchers.IO) {
             val productId = db.productDao().insert(product)
             val sellingPrice = when (product.marginType) {
-                "fixed" -> purchasePrice + product.marginValue
-                "percentage" -> purchasePrice * (1 + product.marginValue / 100)
+                "fixed" -> purchasePrice + (product.marginValue ?: 0.0)
+                "percentage" -> purchasePrice * (1 + (product.marginValue ?: 0.0) / 100)
                 else -> purchasePrice
             }
             db.productPriceDao().insert(


### PR DESCRIPTION
After making Product fields nullable (unitVolume, marginType, marginValue), updated all usages to provide default values using the Elvis operator (?:).

Changes:
- StockMovementActivity: product.unitVolume ?: 1.0
- PurchaseActivity: product.marginValue ?: 0.0 (multiple locations)
- ProductViewModel: product.marginValue ?: 0.0

This resolves type mismatch errors where Double? was inferred but Double was expected.

Default values chosen:
- unitVolume: 1.0 (no volume conversion)
- marginValue: 0.0 (no margin)