### PR TITLE
Fix: Add .first() to Flow call in ProductListActivity

### DIFF
--- a/app/src/main/java/com/medistock/ui/product/ProductListActivity.kt
+++ b/app/src/main/java/com/medistock/ui/product/ProductListActivity.kt
@@ -10,6 +10,7 @@ import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.Product
 import com.medistock.util.PrefsHelper
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -44,6 +45,6 @@ class ProductListActivity : AppCompatActivity() {
     }
 
     private suspend fun getProductsForSite(siteId: Long): List<Product> {
-        return db.productDao().getProductsForSite(siteId)
+        return db.productDao().getProductsForSite(siteId).first()
     }
 }


### PR DESCRIPTION
ProductListActivity was directly assigning Flow<List<Product>> to List<Product>, causing a type mismatch error.

Changed getProductsForSite() to use .first() to get the first emission from the Flow, matching the pattern used in other Activities.

Also added missing import for kotlinx.coroutines.flow.first.