### PR TITLE
Add administration panel for managing sites and categories

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,11 @@
         <activity android:name=".ui.sales.SaleListActivity" android:exported="false" />
         <activity android:name=".ui.purchase.PurchaseActivity" android:exported="false" />
         <activity android:name=".ui.inventory.InventoryActivity" android:exported="false" />
+        <activity android:name=".ui.admin.AdminActivity" android:exported="false" />
+        <activity android:name=".ui.site.SiteListActivity" android:exported="false" />
+        <activity android:name=".ui.site.SiteAddEditActivity" android:exported="false" />
+        <activity android:name=".ui.category.CategoryListActivity" android:exported="false" />
+        <activity android:name=".ui.category.CategoryAddEditActivity" android:exported="false" />
 
     </application>
 

--- a/app/src/main/java/com/medistock/data/dao/SiteDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/SiteDao.kt
@@ -13,6 +13,15 @@ interface SiteDao {
         return insertBlocking(site)
     }
 
+    @Update
+    fun update(site: Site)
+
+    @Delete
+    fun delete(site: Site)
+
     @Query("SELECT * FROM sites")
     fun getAll(): Flow<List<Site>>
+
+    @Query("SELECT * FROM sites WHERE id = :siteId LIMIT 1")
+    fun getById(siteId: Long): Flow<Site?>
 }

--- a/app/src/main/java/com/medistock/ui/HomeActivity.kt
+++ b/app/src/main/java/com/medistock/ui/HomeActivity.kt
@@ -10,6 +10,7 @@ import com.medistock.ui.stock.StockListActivity
 import com.medistock.ui.movement.StockMovementListActivity
 import com.medistock.ui.purchase.PurchaseActivity
 import com.medistock.ui.inventory.InventoryActivity
+import com.medistock.ui.admin.AdminActivity
 
 class HomeActivity : AppCompatActivity() {
 
@@ -39,6 +40,10 @@ class HomeActivity : AppCompatActivity() {
 
         findViewById<android.view.View>(R.id.inventoryButton).setOnClickListener {
             startActivity(Intent(this, InventoryActivity::class.java))
+        }
+
+        findViewById<android.view.View>(R.id.adminButton).setOnClickListener {
+            startActivity(Intent(this, AdminActivity::class.java))
         }
     }
 }

--- a/app/src/main/java/com/medistock/ui/adapters/SiteAdapter.kt
+++ b/app/src/main/java/com/medistock/ui/adapters/SiteAdapter.kt
@@ -1,0 +1,37 @@
+package com.medistock.ui.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.medistock.data.entities.Site
+import com.medistock.databinding.ItemSiteBinding
+
+class SiteAdapter(
+    private val onClick: (Site) -> Unit
+) : RecyclerView.Adapter<SiteAdapter.SiteViewHolder>() {
+
+    private var sites = listOf<Site>()
+
+    fun submitList(list: List<Site>) {
+        sites = list
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SiteViewHolder {
+        val binding = ItemSiteBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+        return SiteViewHolder(binding)
+    }
+
+    override fun getItemCount() = sites.size
+
+    override fun onBindViewHolder(holder: SiteViewHolder, position: Int) {
+        val site = sites[position]
+        holder.binding.textSiteName.text = site.name
+        holder.itemView.setOnClickListener { onClick(site) }
+    }
+
+    class SiteViewHolder(val binding: ItemSiteBinding) :
+        RecyclerView.ViewHolder(binding.root)
+}

--- a/app/src/main/java/com/medistock/ui/admin/AdminActivity.kt
+++ b/app/src/main/java/com/medistock/ui/admin/AdminActivity.kt
@@ -1,0 +1,37 @@
+package com.medistock.ui.admin
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import com.medistock.R
+import com.medistock.ui.category.CategoryListActivity
+import com.medistock.ui.site.SiteListActivity
+
+class AdminActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_admin)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = "Administration"
+
+        findViewById<android.view.View>(R.id.btnManageSites).setOnClickListener {
+            startActivity(Intent(this, SiteListActivity::class.java))
+        }
+
+        findViewById<android.view.View>(R.id.btnManageCategories).setOnClickListener {
+            startActivity(Intent(this, CategoryListActivity::class.java))
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                finish()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+}

--- a/app/src/main/java/com/medistock/ui/site/SiteAddEditActivity.kt
+++ b/app/src/main/java/com/medistock/ui/site/SiteAddEditActivity.kt
@@ -1,0 +1,71 @@
+package com.medistock.ui.site
+
+import android.os.Bundle
+import android.view.MenuItem
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.medistock.R
+import com.medistock.data.db.AppDatabase
+import com.medistock.data.entities.Site
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+class SiteAddEditActivity : AppCompatActivity() {
+    private lateinit var db: AppDatabase
+    private var siteId: Long? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_site_add_edit)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        db = AppDatabase.getInstance(this)
+
+        val editName = findViewById<EditText>(R.id.editSiteName)
+        val btnSave = findViewById<Button>(R.id.btnSaveSite)
+
+        siteId = intent.getLongExtra("SITE_ID", -1).takeIf { it != -1L }
+        if (siteId != null) {
+            supportActionBar?.title = "Modifier le site"
+            CoroutineScope(Dispatchers.IO).launch {
+                val site = db.siteDao().getById(siteId!!).first()
+                runOnUiThread {
+                    if (site != null) {
+                        editName.setText(site.name ?: "")
+                    }
+                }
+            }
+        } else {
+            supportActionBar?.title = "Ajouter un site"
+        }
+
+        btnSave.setOnClickListener {
+            val name = editName.text.toString().trim()
+            if (name.isEmpty()) {
+                Toast.makeText(this, "Nom du site requis", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            CoroutineScope(Dispatchers.IO).launch {
+                if (siteId == null) {
+                    db.siteDao().insert(Site(name = name))
+                } else {
+                    db.siteDao().update(Site(id = siteId!!, name = name))
+                }
+                finish()
+            }
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                finish()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+}

--- a/app/src/main/java/com/medistock/ui/site/SiteListActivity.kt
+++ b/app/src/main/java/com/medistock/ui/site/SiteListActivity.kt
@@ -1,4 +1,4 @@
-package com.medistock.ui.category
+package com.medistock.ui.site
 
 import android.content.Intent
 import android.os.Bundle
@@ -9,47 +9,48 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.medistock.R
 import com.medistock.data.db.AppDatabase
-import com.medistock.ui.adapters.CategoryAdapter
+import com.medistock.ui.adapters.SiteAdapter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
-class CategoryListActivity : AppCompatActivity() {
-    private lateinit var adapter: CategoryAdapter
+class SiteListActivity : AppCompatActivity() {
+    private lateinit var adapter: SiteAdapter
     private lateinit var db: AppDatabase
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_category_list)
+        setContentView(R.layout.activity_site_list)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = "Gestion des sites"
         db = AppDatabase.getInstance(this)
 
-        val recyclerView = findViewById<RecyclerView>(R.id.recyclerCategories)
-        val btnAdd = findViewById<Button>(R.id.btnAddCategory)
+        val recyclerView = findViewById<RecyclerView>(R.id.recyclerSites)
+        val btnAdd = findViewById<Button>(R.id.btnAddSite)
 
         recyclerView.layoutManager = LinearLayoutManager(this)
-        adapter = CategoryAdapter { category ->
-            val intent = Intent(this, CategoryAddEditActivity::class.java)
-            intent.putExtra("CATEGORY_ID", category.id)
+        adapter = SiteAdapter { site ->
+            val intent = Intent(this, SiteAddEditActivity::class.java)
+            intent.putExtra("SITE_ID", site.id)
             startActivity(intent)
         }
         recyclerView.adapter = adapter
 
         btnAdd.setOnClickListener {
-            startActivity(Intent(this, CategoryAddEditActivity::class.java))
+            startActivity(Intent(this, SiteAddEditActivity::class.java))
         }
     }
 
     override fun onResume() {
         super.onResume()
-        loadCategories()
+        loadSites()
     }
 
-    private fun loadCategories() {
+    private fun loadSites() {
         CoroutineScope(Dispatchers.IO).launch {
-            val categories = db.categoryDao().getAll().first()
-            runOnUiThread { adapter.submitList(categories) }
+            val sites = db.siteDao().getAll().first()
+            runOnUiThread { adapter.submitList(sites) }
         }
     }
 

--- a/app/src/main/res/layout/activity_admin.xml
+++ b/app/src/main/res/layout/activity_admin.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Administration"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="32dp" />
+
+    <Button
+        android:id="@+id/btnManageSites"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Gérer les sites"
+        android:layout_marginBottom="16dp"
+        android:padding="16dp" />
+
+    <Button
+        android:id="@+id/btnManageCategories"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Gérer les catégories"
+        android:padding="16dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     android:padding="16dp"
     app:columnCount="3"
-    app:rowCount="2"
+    app:rowCount="3"
     app:alignmentMode="alignMargins"
     app:useDefaultMargins="true">
 
@@ -173,6 +173,35 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Inventaire"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:paddingTop="8dp" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/adminButton"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_columnWeight="1"
+        app:layout_rowWeight="1"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:text="⚙️"
+            android:gravity="center"
+            android:textSize="48sp"
+            android:contentDescription="Administration" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Administration"
             android:textAppearance="?attr/textAppearanceHeadline6"
             android:paddingTop="8dp" />
     </LinearLayout>

--- a/app/src/main/res/layout/activity_site_add_edit.xml
+++ b/app/src/main/res/layout/activity_site_add_edit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="20dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/editSiteName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Nom du site"
+        android:inputType="textPersonName"/>
+
+    <Button
+        android:id="@+id/btnSaveSite"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Enregistrer" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_site_list.xml
+++ b/app/src/main/res/layout/activity_site_list.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/btnAddSite"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Ajouter un site"
+        android:layout_marginBottom="16dp" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerSites"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
+</LinearLayout>

--- a/app/src/main/res/layout/item_site.xml
+++ b/app/src/main/res/layout/item_site.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/textSiteName"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceListItem"
+        android:text="Site Name" />
+</LinearLayout>


### PR DESCRIPTION
This commit adds a complete administration interface to the MediStock app, allowing users to manage sites and categories.

Changes:
- Added SiteDao methods: update, delete, getById
- Created SiteAdapter for RecyclerView display
- Created SiteListActivity to view and manage sites
- Created SiteAddEditActivity for adding/editing sites
- Created AdminActivity as central admin panel
- Added admin button to HomeActivity
- Updated CategoryListActivity to reload data in onResume
- Added all new activities to AndroidManifest.xml

The admin panel provides:
- Site management (add, edit, view list)
- Category management (add, edit, view list)
- Easy navigation from HomeActivity via new admin button