### PR TITLE
Fix product addition validation crash

### DIFF
--- a/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
@@ -8,11 +8,7 @@ import kotlinx.coroutines.flow.Flow
 interface CategoryDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertBlocking(category: Category): Long
-
-    suspend fun insert(category: Category): Long {
-        return insertBlocking(category)
-    }
+    suspend fun insert(category: Category): Long
 
     @Update
     fun update(category: Category)

--- a/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
@@ -7,11 +7,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface InventoryDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertBlocking(inventory: Inventory): Long
-
-    suspend fun insert(inventory: Inventory): Long {
-        return insertBlocking(inventory)
-    }
+    suspend fun insert(inventory: Inventory): Long
 
     @Update
     fun update(inventory: Inventory)

--- a/app/src/main/java/com/medistock/data/dao/ProductDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductDao.kt
@@ -8,12 +8,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ProductDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertBlocking(product: Product): Long  // Version bloquante
-
-    // Ou version avec coroutine wrapper
-    suspend fun insert(product: Product): Long {
-        return insertBlocking(product)
-    }
+    suspend fun insert(product: Product): Long
 
     @Query("SELECT * FROM products")
     fun getAll(): Flow<List<Product>>

--- a/app/src/main/java/com/medistock/data/dao/ProductPriceDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductPriceDao.kt
@@ -8,11 +8,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ProductPriceDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertBlocking(price: ProductPrice): Long
-
-    suspend fun insert(price: ProductPrice): Long {
-        return insertBlocking(price)
-    }
+    suspend fun insert(price: ProductPrice): Long
 
     @Query("SELECT * FROM product_prices")
     fun getAll(): Flow<List<ProductPrice>>

--- a/app/src/main/java/com/medistock/data/dao/ProductSaleDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductSaleDao.kt
@@ -8,11 +8,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ProductSaleDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertBlocking(sale: ProductSale): Long
-
-    suspend fun insert(sale: ProductSale): Long {
-        return insertBlocking(sale)
-    }
+    suspend fun insert(sale: ProductSale): Long
 
     @Query("SELECT * FROM product_sales")
     fun getAll(): Flow<List<ProductSale>>

--- a/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
@@ -7,11 +7,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface PurchaseBatchDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertBlocking(batch: PurchaseBatch): Long
-
-    suspend fun insert(batch: PurchaseBatch): Long {
-        return insertBlocking(batch)
-    }
+    suspend fun insert(batch: PurchaseBatch): Long
 
     @Update
     fun update(batch: PurchaseBatch)

--- a/app/src/main/java/com/medistock/data/dao/SiteDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/SiteDao.kt
@@ -7,11 +7,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface SiteDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertBlocking(site: Site): Long
-
-    suspend fun insert(site: Site): Long {
-        return insertBlocking(site)
-    }
+    suspend fun insert(site: Site): Long
 
     @Update
     fun update(site: Site)

--- a/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
@@ -8,11 +8,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface StockMovementDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertBlocking(movement: StockMovement): Long
-
-    suspend fun insert(movement: StockMovement): Long {
-        return insertBlocking(movement)
-    }
+    suspend fun insert(movement: StockMovement): Long
 
     @Query("SELECT * FROM stock_movements")
     fun getAll(): Flow<List<StockMovement>>


### PR DESCRIPTION
…orrections

This commit fixes critical issues preventing product addition:

1. Fixed all DAO insert methods - Room cannot generate implementations for non-abstract functions with bodies in DAO interfaces. Changed all insert methods from wrapper functions to proper suspend functions with @Insert annotation.

2. Added proper error handling in ProductAddActivity with try-catch block and explicit Dispatchers.IO context for database operations.

3. Added comprehensive validation checks:
   - Initialized selectedUnit with default value "Flacon"
   - Validate selectedUnit is not empty
   - Validate currentSiteId is not 0 (site must be selected)
   - Check categories list is not empty before enabling save button
   - Show clear error messages for each validation failure

4. Fixed DAOs affected: ProductDao, CategoryDao, SiteDao, StockMovementDao, ProductSaleDao, InventoryDao, ProductPriceDao, PurchaseBatchDao

The app should now properly add products without crashes and provide clear feedback when validation fails.