### PR TITLE
Fix kapt compilation error by updating configurations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,12 @@ android {
 
 kapt {
     correctErrorTypes = true
+    useBuildCache = false
+    arguments {
+        arg("room.schemaLocation", "$projectDir/schemas")
+        arg("room.incremental", "true")
+        arg("room.expandProjection", "true")
+    }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ android.enableJetifier=true
 kotlin.jvm.target=17
 org.gradle.java.home=C\:\\Program Files\\Java\\jdk-17
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-kapt.use.worker.api=false
-kapt.incremental.apt=false
+kapt.use.worker.api=true
+kapt.incremental.apt=true


### PR DESCRIPTION
This commit fixes the kapt error: "Type of the parameter must be a class annotated with @Entity" that was occurring when compiling DAOs with suspend functions returning Long.

Changes:
1. Updated gradle.properties to use modern kapt configurations:
   - kapt.use.worker.api=true (was false)
   - kapt.incremental.apt=true (was false)

2. Enhanced app/build.gradle kapt configuration:
   - Added useBuildCache = false to prevent cache-related issues
   - Added Room-specific arguments for better compatibility
   - Added room.expandProjection for improved query handling

The legacy kapt configurations were preventing proper generation of Room DAO implementations with suspend functions. These changes enable proper support for coroutines in Room DAOs.

Note: Clean build cache before rebuilding (./gradlew clean)