### PR TITLE
Change DAO insert functions from suspend to blocking to fix kapt error

### DIFF
--- a/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 interface CategoryDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(category: Category): Long
+    fun insert(category: Category): Long
 
     @Update
     fun update(category: Category)

--- a/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface InventoryDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(inventory: Inventory): Long
+    fun insert(inventory: Inventory): Long
 
     @Update
     fun update(inventory: Inventory)

--- a/app/src/main/java/com/medistock/data/dao/ProductDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductDao.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ProductDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(product: Product): Long
+    fun insert(product: Product): Long
 
     @Query("SELECT * FROM products")
     fun getAll(): Flow<List<Product>>

--- a/app/src/main/java/com/medistock/data/dao/ProductPriceDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductPriceDao.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ProductPriceDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(price: ProductPrice): Long
+    fun insert(price: ProductPrice): Long
 
     @Query("SELECT * FROM product_prices")
     fun getAll(): Flow<List<ProductPrice>>

--- a/app/src/main/java/com/medistock/data/dao/ProductSaleDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductSaleDao.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ProductSaleDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(sale: ProductSale): Long
+    fun insert(sale: ProductSale): Long
 
     @Query("SELECT * FROM product_sales")
     fun getAll(): Flow<List<ProductSale>>

--- a/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface PurchaseBatchDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(batch: PurchaseBatch): Long
+    fun insert(batch: PurchaseBatch): Long
 
     @Update
     fun update(batch: PurchaseBatch)

--- a/app/src/main/java/com/medistock/data/dao/SiteDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/SiteDao.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface SiteDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(site: Site): Long
+    fun insert(site: Site): Long
 
     @Update
     fun update(site: Site)

--- a/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface StockMovementDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(movement: StockMovement): Long
+    fun insert(movement: StockMovement): Long
 
     @Query("SELECT * FROM stock_movements")
     fun getAll(): Flow<List<StockMovement>>


### PR DESCRIPTION
This commit fixes the kapt compilation error: "Type of the parameter must be a class annotated with @Entity or a collection/array of it."

The issue was that Room's kapt annotation processor in version 2.5.2 has trouble generating proper implementations for suspend functions returning Long in certain configurations.

Solution:
- Changed all DAO insert functions from 'suspend fun' to regular 'fun'
- Functions now return Long directly without suspend modifier
- All calling code already uses withContext(Dispatchers.IO) or viewModelScope.launch(Dispatchers.IO), so no changes needed there

DAOs modified:
- ProductDao
- CategoryDao
- SiteDao
- StockMovementDao
- ProductSaleDao
- InventoryDao
- ProductPriceDao
- PurchaseBatchDao

This approach is more compatible with Room 2.5.2 and allows kapt to properly generate DAO implementations.