### PR TITLE
Fix ProductAdapter compatibility with MainActivity

### DIFF
--- a/app/src/main/java/com/medistock/ui/MainActivity.kt
+++ b/app/src/main/java/com/medistock/ui/MainActivity.kt
@@ -13,7 +13,7 @@ import androidx.room.Room
 import com.medistock.R
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.ProductWithCategory
-import com.medistock.ui.adapters.ProductAdapter
+import com.medistock.ui.adapters.ProductWithCategoryAdapter
 import com.medistock.ui.product.ProductAddActivity
 import com.medistock.util.PrefsHelper
 import kotlinx.coroutines.launch
@@ -22,7 +22,7 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var db: AppDatabase
     private lateinit var recyclerView: RecyclerView
-    private lateinit var adapter: ProductAdapter
+    private lateinit var adapter: ProductWithCategoryAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -37,7 +37,7 @@ class MainActivity : AppCompatActivity() {
         lifecycleScope.launch {
             val siteId = PrefsHelper.getActiveSiteId(this@MainActivity)
             db.productDao().getProductsWithCategoryForSite(siteId).collect { products ->
-                adapter = ProductAdapter(products)
+                adapter = ProductWithCategoryAdapter(products)
                 recyclerView.adapter = adapter
             }
         }

--- a/app/src/main/java/com/medistock/ui/adapters/ProductWithCategoryAdapter.kt
+++ b/app/src/main/java/com/medistock/ui/adapters/ProductWithCategoryAdapter.kt
@@ -1,0 +1,31 @@
+package com.medistock.ui.adapters
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.medistock.R
+import com.medistock.data.entities.ProductWithCategory
+
+class ProductWithCategoryAdapter(private val products: List<ProductWithCategory>) :
+    RecyclerView.Adapter<ProductWithCategoryAdapter.ProductViewHolder>() {
+
+    class ProductViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val textProductName: TextView = itemView.findViewById(R.id.textProductName)
+        val textProductCategory: TextView = itemView.findViewById(R.id.textProductCategory)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_product, parent, false)
+        return ProductViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ProductViewHolder, position: Int) {
+        val product = products[position]
+        holder.textProductName.text = product.name
+        holder.textProductCategory.text = product.categoryName
+    }
+
+    override fun getItemCount(): Int = products.size
+}


### PR DESCRIPTION
- Create ProductWithCategoryAdapter for MainActivity to display products with categories
- Update MainActivity to use ProductWithCategoryAdapter instead of ProductAdapter
- ProductAdapter now focuses on Product management in ProductListActivity