### PR TITLE
Move Manage Products to Administration panel

### DIFF
--- a/app/src/main/java/com/medistock/ui/HomeActivity.kt
+++ b/app/src/main/java/com/medistock/ui/HomeActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.medistock.R
 import com.medistock.ui.sales.SaleListActivity
-import com.medistock.ui.manage.ManageProductMenuActivity
 import com.medistock.ui.stock.StockListActivity
 import com.medistock.ui.movement.StockMovementListActivity
 import com.medistock.ui.purchase.PurchaseActivity
@@ -24,10 +23,6 @@ class HomeActivity : AppCompatActivity() {
 
         findViewById<android.view.View>(R.id.sellProductButton).setOnClickListener {
             startActivity(Intent(this, SaleListActivity::class.java))
-        }
-
-        findViewById<android.view.View>(R.id.manageProductButton).setOnClickListener {
-            startActivity(Intent(this, ManageProductMenuActivity::class.java))
         }
 
         findViewById<android.view.View>(R.id.stockMovementButton).setOnClickListener {

--- a/app/src/main/java/com/medistock/ui/admin/AdminActivity.kt
+++ b/app/src/main/java/com/medistock/ui/admin/AdminActivity.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import com.medistock.R
-import com.medistock.ui.category.CategoryListActivity
+import com.medistock.ui.manage.ManageProductMenuActivity
 import com.medistock.ui.site.SiteListActivity
 
 class AdminActivity : AppCompatActivity() {
@@ -20,8 +20,8 @@ class AdminActivity : AppCompatActivity() {
             startActivity(Intent(this, SiteListActivity::class.java))
         }
 
-        findViewById<android.view.View>(R.id.btnManageCategories).setOnClickListener {
-            startActivity(Intent(this, CategoryListActivity::class.java))
+        findViewById<android.view.View>(R.id.btnManageProducts).setOnClickListener {
+            startActivity(Intent(this, ManageProductMenuActivity::class.java))
         }
     }
 

--- a/app/src/main/res/layout/activity_admin.xml
+++ b/app/src/main/res/layout/activity_admin.xml
@@ -18,15 +18,15 @@
         android:id="@+id/btnManageSites"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Gérer les sites"
+        android:text="Site Management"
         android:layout_marginBottom="16dp"
         android:padding="16dp" />
 
     <Button
-        android:id="@+id/btnManageCategories"
+        android:id="@+id/btnManageProducts"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Gérer les catégories"
+        android:text="Manage Products"
         android:padding="16dp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -66,33 +66,6 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/manageProductButton"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_columnWeight="1"
-        app:layout_rowWeight="1"
-        android:orientation="vertical"
-        android:gravity="center"
-        android:background="?attr/selectableItemBackground"
-        android:clickable="true"
-        android:focusable="true"
-        android:padding="16dp">
-
-        <ImageView
-            android:layout_width="64dp"
-            android:layout_height="64dp"
-            android:src="@drawable/ic_manage"
-            android:contentDescription="@string/manage_product" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/manage_product"
-            android:textAppearance="?attr/textAppearanceHeadline6"
-            android:paddingTop="8dp" />
-    </LinearLayout>
-
-    <LinearLayout
         android:id="@+id/stockMovementButton"
         android:layout_width="0dp"
         android:layout_height="0dp"


### PR DESCRIPTION
- Move Manage Products button from Home screen to Administration panel
- Replace "Gérer les catégories" with "Manage Products" in AdminActivity
- Rename "Gérer les sites" to "Site Management" for consistency
- Remove Manage Products button from Home screen layout
- Update AdminActivity to launch ManageProductMenuActivity