### PR TITLE
Add product filtering to stock view

### DIFF
--- a/app/src/main/res/layout/activity_stock_list.xml
+++ b/app/src/main/res/layout/activity_stock_list.xml
@@ -11,6 +11,13 @@
         android:layout_height="wrap_content"
         android:spinnerMode="dropdown"/>
 
+    <Spinner
+        android:id="@+id/spinnerProducts"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:spinnerMode="dropdown"/>
+
     <TextView
         android:id="@+id/textStockSummary"
         android:layout_width="match_parent"


### PR DESCRIPTION
Added the ability to filter stock by product in addition to site filtering. Users can now select a specific product from a dropdown to view its stock across all sites or at a specific site.

Changes:
- Added getCurrentStockForProduct() and getCurrentStockForProductAndSite() methods to StockMovementDao for product-based filtering
- Added product spinner to activity_stock_list.xml layout
- Updated StockListActivity to load products and handle combined site/product filtering with four filter combinations:
  * All sites + all products
  * Specific site + all products
  * All sites + specific product
  * Specific site + specific product