### PR TITLE
Add 'All' button to permission rows for quick permission selection

### DIFF
--- a/app/src/main/java/com/medistock/ui/user/UserAddEditActivity.kt
+++ b/app/src/main/java/com/medistock/ui/user/UserAddEditActivity.kt
@@ -110,6 +110,7 @@ class UserAddEditActivity : AppCompatActivity() {
             val permView = LayoutInflater.from(this).inflate(R.layout.item_permission, permissionsContainer, false)
 
             val tvModuleName = permView.findViewById<TextView>(R.id.tvModuleName)
+            val btnSelectAll = permView.findViewById<Button>(R.id.btnSelectAll)
             val checkCanView = permView.findViewById<CheckBox>(R.id.checkCanView)
             val checkCanCreate = permView.findViewById<CheckBox>(R.id.checkCanCreate)
             val checkCanEdit = permView.findViewById<CheckBox>(R.id.checkCanEdit)
@@ -118,9 +119,23 @@ class UserAddEditActivity : AppCompatActivity() {
             tvModuleName.text = moduleName
             permissionsContainer.addView(permView)
 
-            permissionViews[moduleKey] = PermissionCheckboxes(
-                checkCanView, checkCanCreate, checkCanEdit, checkCanDelete
+            val permCheckboxes = PermissionCheckboxes(
+                checkCanView, checkCanCreate, checkCanEdit, checkCanDelete, btnSelectAll
             )
+
+            // Handle "All" button click
+            btnSelectAll.setOnClickListener {
+                val allChecked = checkCanView.isChecked && checkCanCreate.isChecked &&
+                                checkCanEdit.isChecked && checkCanDelete.isChecked
+                val newState = !allChecked
+
+                checkCanView.isChecked = newState
+                checkCanCreate.isChecked = newState
+                checkCanEdit.isChecked = newState
+                checkCanDelete.isChecked = newState
+            }
+
+            permissionViews[moduleKey] = permCheckboxes
         }
     }
 
@@ -372,13 +387,15 @@ class UserAddEditActivity : AppCompatActivity() {
         val canView: CheckBox,
         val canCreate: CheckBox,
         val canEdit: CheckBox,
-        val canDelete: CheckBox
+        val canDelete: CheckBox,
+        val selectAllButton: Button? = null
     ) {
         fun setEnabled(enabled: Boolean) {
             canView.isEnabled = enabled
             canCreate.isEnabled = enabled
             canEdit.isEnabled = enabled
             canDelete.isEnabled = enabled
+            selectAllButton?.isEnabled = enabled
         }
     }
 }

--- a/app/src/main/res/layout/item_permission.xml
+++ b/app/src/main/res/layout/item_permission.xml
@@ -19,7 +19,19 @@
     <LinearLayout
         android:orientation="horizontal"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical">
+
+        <Button
+            android:id="@+id/btnSelectAll"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:text="All"
+            android:textSize="12sp"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:layout_marginEnd="8dp"
+            style="?android:attr/buttonBarButtonStyle"/>
 
         <CheckBox
             android:id="@+id/checkCanView"


### PR DESCRIPTION
- Added 'All' button to each permission row in item_permission.xml
- Button toggles all four checkboxes (View, Create, Edit, Delete) for that module
- Button automatically disables when user is marked as administrator
- Smart toggle: checks all if any unchecked, unchecks all if all checked
- Simple UI enhancement for faster permission assignment