### PR TITLE
Fix password migration execution order

### DIFF
--- a/app/src/main/java/com/medistock/ui/auth/LoginActivity.kt
+++ b/app/src/main/java/com/medistock/ui/auth/LoginActivity.kt
@@ -38,25 +38,32 @@ class LoginActivity : AppCompatActivity() {
         authManager = AuthManager.getInstance(this)
         db = AppDatabase.getInstance(this)
 
-        // Check if already logged in
-        if (authManager.isLoggedIn()) {
-            navigateToHome()
-            return
-        }
-
         // Initialize views
         editUsername = findViewById(R.id.editUsername)
         editPassword = findViewById(R.id.editPassword)
         btnLogin = findViewById(R.id.btnLogin)
         tvError = findViewById(R.id.tvError)
 
-        // Create default admin user if no users exist and migrate passwords
+        // Disable login button during initialization
+        btnLogin.isEnabled = false
+
+        // IMPORTANT: Migrate passwords BEFORE checking login status
         lifecycleScope.launch {
             // Migrate existing plain text passwords to hashed passwords
             PasswordMigration.migratePasswordsIfNeeded(this@LoginActivity)
 
             // Create default admin user if needed
             createDefaultAdminIfNeeded()
+
+            // After migration, check if already logged in
+            withContext(Dispatchers.Main) {
+                if (authManager.isLoggedIn()) {
+                    navigateToHome()
+                } else {
+                    // Enable login button
+                    btnLogin.isEnabled = true
+                }
+            }
         }
 
         btnLogin.setOnClickListener {


### PR DESCRIPTION
Critical fix: Ensure password migration runs BEFORE login check.

Previously, if a user was already logged in, the app would navigate to HomeActivity without running the password migration, leaving plain text passwords in the database.

Now the migration:
- Runs on every app start (before login check)
- Executes only once (tracked via SharedPreferences)
- Migrates all existing plain text passwords to BCrypt hashes
- Login button is disabled during migration to prevent issues

This ensures all passwords are properly hashed, even for existing users.