### PR TITLE
Add missing CardView and RecyclerView dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,10 @@ dependencies {
     implementation "androidx.activity:activity-ktx:1.7.2"
     implementation "androidx.gridlayout:gridlayout:1.0.0"
 
+    // RecyclerView and CardView
+    implementation "androidx.recyclerview:recyclerview:1.3.1"
+    implementation "androidx.cardview:cardview:1.0.0"
+
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 }


### PR DESCRIPTION
The sale screen layouts use CardView which was not in dependencies, causing the app to crash on startup.