### PR TITLE
Fix SaleActivity not opening and edit sale bug

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
         <activity android:name=".ui.movement.StockMovementListActivity" android:exported="false" />
         <activity android:name=".ui.stock.StockListActivity" android:exported="false" />
         <activity android:name=".ui.sales.SaleListActivity" android:exported="false" />
+        <activity android:name=".ui.sales.SaleActivity" android:exported="false" />
         <activity android:name=".ui.purchase.PurchaseActivity" android:exported="false" />
         <activity android:name=".ui.inventory.InventoryActivity" android:exported="false" />
         <activity android:name=".ui.admin.AdminActivity" android:exported="false" />

--- a/app/src/main/java/com/medistock/ui/sales/SaleActivity.kt
+++ b/app/src/main/java/com/medistock/ui/sales/SaleActivity.kt
@@ -287,11 +287,10 @@ class SaleActivity : AppCompatActivity() {
                     )
                     db.saleDao().update(updatedSale)
 
-                    // Delete old sale items
-                    db.saleItemDao().deleteAllForSale(editingSaleId!!)
+                    // Get old items BEFORE deleting them
+                    val oldItems = db.saleItemDao().getItemsForSale(editingSaleId!!).first()
 
                     // Reverse old stock movements by adding back
-                    val oldItems = db.saleItemDao().getItemsForSale(editingSaleId!!).first()
                     oldItems.forEach { oldItem ->
                         val movement = StockMovement(
                             productId = oldItem.productId,
@@ -304,6 +303,9 @@ class SaleActivity : AppCompatActivity() {
                         )
                         db.stockMovementDao().insert(movement)
                     }
+
+                    // Delete old sale items AFTER reversing stock
+                    db.saleItemDao().deleteAllForSale(editingSaleId!!)
 
                     // Insert new sale items and stock movements
                     saleItemAdapter.getItems().forEach { item ->


### PR DESCRIPTION
- Add SaleActivity to AndroidManifest.xml (was missing)
- Fix bug where old sale items were retrieved AFTER deletion
- Now get old items BEFORE deleting them for proper stock reversal