### PR TITLE
Fix: Replace LocalDateTime with Long for timestamps

### DIFF
--- a/app/src/main/java/com/medistock/data/entities/PackagingType.kt
+++ b/app/src/main/java/com/medistock/data/entities/PackagingType.kt
@@ -2,7 +2,6 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import java.time.LocalDateTime
 
 /**
  * PackagingType - Type de conditionnement administrable
@@ -37,8 +36,8 @@ data class PackagingType(
     val displayOrder: Int = 0,
 
     // Audit
-    val createdAt: LocalDateTime = LocalDateTime.now(),
-    val updatedAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis(),
     val createdBy: String? = null,
     val updatedBy: String? = null
 ) {

--- a/app/src/main/java/com/medistock/ui/packaging/PackagingTypeAddEditActivity.kt
+++ b/app/src/main/java/com/medistock/ui/packaging/PackagingTypeAddEditActivity.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.ViewModelProvider
 import com.medistock.R
 import com.medistock.data.entities.PackagingType
 import com.medistock.ui.viewmodel.PackagingTypeViewModel
-import java.time.LocalDateTime
 
 class PackagingTypeAddEditActivity : AppCompatActivity() {
 
@@ -152,8 +151,8 @@ class PackagingTypeAddEditActivity : AppCompatActivity() {
             defaultConversionFactor = conversionFactor,
             isActive = isActive,
             displayOrder = existingPackagingType?.displayOrder ?: 0,
-            createdAt = existingPackagingType?.createdAt ?: LocalDateTime.now(),
-            updatedAt = LocalDateTime.now(),
+            createdAt = existingPackagingType?.createdAt ?: System.currentTimeMillis(),
+            updatedAt = System.currentTimeMillis(),
             createdBy = existingPackagingType?.createdBy,
             updatedBy = null // TODO: Add current user
         )


### PR DESCRIPTION
Changed PackagingType to use Long timestamps instead of LocalDateTime to maintain consistency with other entities in the project:

- PackagingType.kt: Changed createdAt and updatedAt from LocalDateTime to Long
- PackagingTypeAddEditActivity.kt: Updated to use System.currentTimeMillis() instead of LocalDateTime.now()

This fixes Room compilation error as the project doesn't have TypeConverters for LocalDateTime and all other entities use Long for timestamps.