### PR TITLE
Fix: Update ProductWithPackaging to use non-nullable unit fields

### DIFF
--- a/app/src/main/java/com/medistock/data/entities/ProductWithPackaging.kt
+++ b/app/src/main/java/com/medistock/data/entities/ProductWithPackaging.kt
@@ -19,14 +19,14 @@ data class ProductWithPackaging(
      * Retourne l'unité effective à afficher
      */
     fun getEffectiveUnit(): String {
-        return product.getEffectiveUnit(packagingType)
+        return product.unit
     }
 
     /**
      * Retourne le facteur de conversion effectif
      */
     fun getEffectiveConversionFactor(): Double {
-        return product.getEffectiveConversionFactor(packagingType)
+        return product.unitVolume
     }
 
     /**
@@ -49,7 +49,7 @@ data class ProductWithPackaging(
             val levelName = packagingType.getLevelName(product.selectedLevel)
             "$typeName (utilise $levelName)"
         } else {
-            product.unit ?: "Units"
+            product.unit
         }
     }
 }


### PR DESCRIPTION
- Changed getEffectiveUnit() to directly return product.unit
- Changed getEffectiveConversionFactor() to directly return product.unitVolume
- Removed elvis operator in getPackagingDisplayName() since unit is now non-nullable

These helper methods no longer need to compute values since unit and unitVolume are now populated directly when products are saved.