### PR TITLE
Fix: Correct DAO method calls in audited repositories

### DIFF
--- a/app/src/main/java/com/medistock/data/repository/AuditedPurchaseBatchRepository.kt
+++ b/app/src/main/java/com/medistock/data/repository/AuditedPurchaseBatchRepository.kt
@@ -80,7 +80,7 @@ class AuditedPurchaseBatchRepository(private val context: Context) {
     }
 
     fun delete(batch: PurchaseBatch) {
-        purchaseBatchDao.delete(batch)
+        purchaseBatchDao.deleteById(batch.id)
 
         auditLogger.logDelete(
             entityType = "PurchaseBatch",

--- a/app/src/main/java/com/medistock/data/repository/AuditedUserRepository.kt
+++ b/app/src/main/java/com/medistock/data/repository/AuditedUserRepository.kt
@@ -16,7 +16,7 @@ class AuditedUserRepository(private val context: Context) {
     private val authManager = AuthManager.getInstance(context)
 
     fun insert(user: User): Long {
-        val userId = userDao.insert(user)
+        val userId = userDao.insertUser(user)
 
         // Log the insert action (don't log password)
         auditLogger.logInsert(
@@ -37,7 +37,7 @@ class AuditedUserRepository(private val context: Context) {
     }
 
     fun update(oldUser: User, newUser: User) {
-        userDao.update(newUser)
+        userDao.updateUser(newUser)
 
         // Track changes
         val changes = mutableMapOf<String, Pair<String?, String?>>()
@@ -69,7 +69,7 @@ class AuditedUserRepository(private val context: Context) {
     }
 
     fun delete(user: User) {
-        userDao.delete(user)
+        userDao.deleteUser(user)
 
         auditLogger.logDelete(
             entityType = "User",


### PR DESCRIPTION
Fixed method name mismatches between repositories and DAOs:
- PurchaseBatchDao uses deleteById() not delete()
- UserDao uses insertUser(), updateUser(), deleteUser()

This resolves compilation errors in the audit repositories.