### PR TITLE
Fix: Remove suspend function and use sync DAO method in BatchTransfer…

### DIFF
--- a/app/src/main/java/com/medistock/util/BatchTransferHelper.kt
+++ b/app/src/main/java/com/medistock/util/BatchTransferHelper.kt
@@ -2,7 +2,6 @@ package com.medistock.util
 
 import com.medistock.data.dao.PurchaseBatchDao
 import com.medistock.data.entities.PurchaseBatch
-import kotlinx.coroutines.flow.first
 
 /**
  * Helper class to manage FIFO batch transfers between sites.
@@ -14,14 +13,14 @@ class BatchTransferHelper(private val batchDao: PurchaseBatchDao) {
      * Transfer quantity from source site to destination site using FIFO.
      * Returns list of batch transfers (source batch info for creating destination batches).
      */
-    suspend fun transferBatchesFIFO(
+    fun transferBatchesFIFO(
         productId: Long,
         fromSiteId: Long,
         toSiteId: Long,
         totalQuantity: Double,
         currentUser: String
     ): List<BatchTransferInfo> {
-        val batches = batchDao.getAvailableBatchesFIFO(productId, fromSiteId).first()
+        val batches = batchDao.getAvailableBatchesFIFOSync(productId, fromSiteId)
         var remainingToTransfer = totalQuantity
         val transferInfoList = mutableListOf<BatchTransferInfo>()
 


### PR DESCRIPTION
…Helper

Changes:
- Remove 'suspend' keyword from transferBatchesFIFO function
- Use getAvailableBatchesFIFOSync instead of Flow-based getAvailableBatchesFIFO
- Remove unused kotlinx.coroutines.flow.first import
- Follows codebase pattern of avoiding suspend functions (causes crashes)
- Aligns with AuditedRepository pattern used throughout the app