### PR TITLE
Update compileSdk and targetSdk to 34 for Supabase compatibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace 'com.medistock'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.medistock"
         minSdk 26
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Fix AAR metadata error from androidx.browser:browser:1.7.0 dependency which requires compileSdk 34 or later.

Changes:
- compileSdk: 33 → 34
- targetSdk: 33 → 34
- minSdk: 26 (unchanged)