### PR TITLE
Fix all repository compilation errors

### DIFF
--- a/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
@@ -5,7 +5,7 @@ import com.medistock.data.remote.dto.AuditHistoryDto
 /**
  * Repository pour l'historique d'audit
  */
-class AuditHistorySupabaseRepository : BaseSupabaseRepository<AuditHistoryDto>("audit_history") {
+class AuditHistorySupabaseRepository : BaseSupabaseRepository("audit_history") {
 
     suspend fun getAllAuditHistory(): List<AuditHistoryDto> = getAll()
 

--- a/app/src/main/java/com/medistock/data/remote/repository/BaseSupabaseRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BaseSupabaseRepository.kt
@@ -3,17 +3,17 @@ package com.medistock.data.remote.repository
 import com.medistock.data.remote.SupabaseClientProvider
 import io.github.jan.supabase.postgrest.from
 import io.github.jan.supabase.postgrest.query.Columns
+import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
 
 /**
  * Repository de base avec les opérations CRUD communes pour toutes les tables
  *
- * @param T Type du DTO
  * @param tableName Nom de la table dans Supabase
  */
-abstract class BaseSupabaseRepository<T : Any>(
-    protected val tableName: String
+abstract class BaseSupabaseRepository(
+    val tableName: String
 ) {
-    protected val supabase = SupabaseClientProvider.client
+    val supabase = SupabaseClientProvider.client
 
     /**
      * Récupère tous les enregistrements
@@ -75,7 +75,7 @@ abstract class BaseSupabaseRepository<T : Any>(
      * Récupère les enregistrements avec un filtre personnalisé
      */
     suspend inline fun <reified R> getWithFilter(
-        noinline filterBlock: suspend io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder.() -> Unit
+        noinline filterBlock: suspend PostgrestFilterBuilder.() -> Unit
     ): List<R> {
         return supabase.from(tableName).select {
             filter(filterBlock)
@@ -86,7 +86,7 @@ abstract class BaseSupabaseRepository<T : Any>(
      * Compte le nombre d'enregistrements avec un filtre optionnel
      */
     suspend fun count(
-        filterBlock: (suspend io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder.() -> Unit)? = null
+        filterBlock: (suspend PostgrestFilterBuilder.() -> Unit)? = null
     ): Long {
         val result = if (filterBlock != null) {
             supabase.from(tableName).select(Columns.raw("count")) {

--- a/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
@@ -5,7 +5,7 @@ import com.medistock.data.remote.dto.*
 /**
  * Repository pour les sites
  */
-class SiteSupabaseRepository : BaseSupabaseRepository<SiteDto>("sites") {
+class SiteSupabaseRepository : BaseSupabaseRepository("sites") {
 
     suspend fun getAllSites(): List<SiteDto> = getAll()
 
@@ -30,7 +30,7 @@ class SiteSupabaseRepository : BaseSupabaseRepository<SiteDto>("sites") {
 /**
  * Repository pour les catégories
  */
-class CategorySupabaseRepository : BaseSupabaseRepository<CategoryDto>("categories") {
+class CategorySupabaseRepository : BaseSupabaseRepository("categories") {
 
     suspend fun getAllCategories(): List<CategoryDto> = getAll()
 
@@ -55,7 +55,7 @@ class CategorySupabaseRepository : BaseSupabaseRepository<CategoryDto>("categori
 /**
  * Repository pour les types de conditionnement
  */
-class PackagingTypeSupabaseRepository : BaseSupabaseRepository<PackagingTypeDto>("packaging_types") {
+class PackagingTypeSupabaseRepository : BaseSupabaseRepository("packaging_types") {
 
     suspend fun getAllPackagingTypes(): List<PackagingTypeDto> = getAll()
 
@@ -89,7 +89,7 @@ class PackagingTypeSupabaseRepository : BaseSupabaseRepository<PackagingTypeDto>
 /**
  * Repository pour les clients
  */
-class CustomerSupabaseRepository : BaseSupabaseRepository<CustomerDto>("customers") {
+class CustomerSupabaseRepository : BaseSupabaseRepository("customers") {
 
     suspend fun getAllCustomers(): List<CustomerDto> = getAll()
 

--- a/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
@@ -7,7 +7,7 @@ import com.medistock.data.remote.dto.CurrentStockDto
 /**
  * Repository pour les produits
  */
-class ProductSupabaseRepository : BaseSupabaseRepository<ProductDto>("products") {
+class ProductSupabaseRepository : BaseSupabaseRepository("products") {
 
     suspend fun getAllProducts(): List<ProductDto> = getAll()
 
@@ -68,7 +68,7 @@ class ProductSupabaseRepository : BaseSupabaseRepository<ProductDto>("products")
 /**
  * Repository pour les prix des produits
  */
-class ProductPriceSupabaseRepository : BaseSupabaseRepository<ProductPriceDto>("product_prices") {
+class ProductPriceSupabaseRepository : BaseSupabaseRepository("product_prices") {
 
     suspend fun getAllPrices(): List<ProductPriceDto> = getAll()
 
@@ -116,7 +116,7 @@ class ProductPriceSupabaseRepository : BaseSupabaseRepository<ProductPriceDto>("
 /**
  * Repository pour la vue current_stock (lecture seule)
  */
-class CurrentStockRepository : BaseSupabaseRepository<CurrentStockDto>("current_stock") {
+class CurrentStockRepository : BaseSupabaseRepository("current_stock") {
 
     suspend fun getAllStock(): List<CurrentStockDto> = getAll()
 

--- a/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
@@ -5,7 +5,7 @@ import com.medistock.data.remote.dto.*
 /**
  * Repository pour les ventes
  */
-class SaleSupabaseRepository : BaseSupabaseRepository<SaleDto>("sales") {
+class SaleSupabaseRepository : BaseSupabaseRepository("sales") {
 
     suspend fun getAllSales(): List<SaleDto> = getAll()
 
@@ -78,7 +78,7 @@ class SaleSupabaseRepository : BaseSupabaseRepository<SaleDto>("sales") {
 /**
  * Repository pour les lignes de vente
  */
-class SaleItemSupabaseRepository : BaseSupabaseRepository<SaleItemDto>("sale_items") {
+class SaleItemSupabaseRepository : BaseSupabaseRepository("sale_items") {
 
     suspend fun getAllSaleItems(): List<SaleItemDto> = getAll()
 
@@ -123,7 +123,7 @@ class SaleItemSupabaseRepository : BaseSupabaseRepository<SaleItemDto>("sale_ite
 /**
  * Repository pour les allocations FIFO des batches aux ventes
  */
-class SaleBatchAllocationSupabaseRepository : BaseSupabaseRepository<SaleBatchAllocationDto>("sale_batch_allocations") {
+class SaleBatchAllocationSupabaseRepository : BaseSupabaseRepository("sale_batch_allocations") {
 
     suspend fun getAllAllocations(): List<SaleBatchAllocationDto> = getAll()
 
@@ -165,7 +165,7 @@ class SaleBatchAllocationSupabaseRepository : BaseSupabaseRepository<SaleBatchAl
 /**
  * Repository pour les ventes produits (ancien système)
  */
-class ProductSaleSupabaseRepository : BaseSupabaseRepository<ProductSaleDto>("product_sales") {
+class ProductSaleSupabaseRepository : BaseSupabaseRepository("product_sales") {
 
     suspend fun getAllProductSales(): List<ProductSaleDto> = getAll()
 

--- a/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
@@ -5,7 +5,7 @@ import com.medistock.data.remote.dto.*
 /**
  * Repository pour les lots d'achat (FIFO)
  */
-class PurchaseBatchSupabaseRepository : BaseSupabaseRepository<PurchaseBatchDto>("purchase_batches") {
+class PurchaseBatchSupabaseRepository : BaseSupabaseRepository("purchase_batches") {
 
     suspend fun getAllBatches(): List<PurchaseBatchDto> = getAll()
 
@@ -73,7 +73,7 @@ class PurchaseBatchSupabaseRepository : BaseSupabaseRepository<PurchaseBatchDto>
 /**
  * Repository pour les mouvements de stock
  */
-class StockMovementSupabaseRepository : BaseSupabaseRepository<StockMovementDto>("stock_movements") {
+class StockMovementSupabaseRepository : BaseSupabaseRepository("stock_movements") {
 
     suspend fun getAllMovements(): List<StockMovementDto> = getAll()
 
@@ -136,7 +136,7 @@ class StockMovementSupabaseRepository : BaseSupabaseRepository<StockMovementDto>
 /**
  * Repository pour les inventaires
  */
-class InventorySupabaseRepository : BaseSupabaseRepository<InventoryDto>("inventories") {
+class InventorySupabaseRepository : BaseSupabaseRepository("inventories") {
 
     suspend fun getAllInventories(): List<InventoryDto> = getAll()
 
@@ -197,7 +197,7 @@ class InventorySupabaseRepository : BaseSupabaseRepository<InventoryDto>("invent
 /**
  * Repository pour les transferts de produits
  */
-class ProductTransferSupabaseRepository : BaseSupabaseRepository<ProductTransferDto>("product_transfers") {
+class ProductTransferSupabaseRepository : BaseSupabaseRepository("product_transfers") {
 
     suspend fun getAllTransfers(): List<ProductTransferDto> = getAll()
 

--- a/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
@@ -6,7 +6,7 @@ import com.medistock.data.remote.dto.UserPermissionDto
 /**
  * Repository pour les utilisateurs
  */
-class UserSupabaseRepository : BaseSupabaseRepository<AppUserDto>("app_users") {
+class UserSupabaseRepository : BaseSupabaseRepository("app_users") {
 
     suspend fun getAllUsers(): List<AppUserDto> = getAll()
 
@@ -57,7 +57,7 @@ class UserSupabaseRepository : BaseSupabaseRepository<AppUserDto>("app_users") {
 /**
  * Repository pour les permissions utilisateur
  */
-class UserPermissionSupabaseRepository : BaseSupabaseRepository<UserPermissionDto>("user_permissions") {
+class UserPermissionSupabaseRepository : BaseSupabaseRepository("user_permissions") {
 
     suspend fun getAllPermissions(): List<UserPermissionDto> = getAll()
 


### PR DESCRIPTION
- Remove generic type parameter from BaseSupabaseRepository
- Change tableName and supabase from protected to public for inline functions
- Add missing import for PostgrestFilterBuilder
- Update all repository classes to remove generic type in extends clause
- All repositories now simply extend BaseSupabaseRepository(tableName)

This fixes all 'Protected function call from public-API inline function' errors and 'Unresolved reference' errors across all repository files.