### PR TITLE
Add required Supabase imports to all repository files

### DIFF
--- a/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
@@ -1,5 +1,9 @@
 package com.medistock.data.remote.repository
 
+
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
+
 import com.medistock.data.remote.dto.AuditHistoryDto
 
 /**

--- a/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
@@ -1,5 +1,9 @@
 package com.medistock.data.remote.repository
 
+
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
+
 import com.medistock.data.remote.dto.*
 
 /**

--- a/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
@@ -1,5 +1,9 @@
 package com.medistock.data.remote.repository
 
+
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
+
 import com.medistock.data.remote.dto.ProductDto
 import com.medistock.data.remote.dto.ProductPriceDto
 import com.medistock.data.remote.dto.CurrentStockDto

--- a/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
@@ -1,5 +1,9 @@
 package com.medistock.data.remote.repository
 
+
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
+
 import com.medistock.data.remote.dto.*
 
 /**

--- a/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
@@ -1,5 +1,9 @@
 package com.medistock.data.remote.repository
 
+
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
+
 import com.medistock.data.remote.dto.*
 
 /**

--- a/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
@@ -1,5 +1,9 @@
 package com.medistock.data.remote.repository
 
+
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
+
 import com.medistock.data.remote.dto.AppUserDto
 import com.medistock.data.remote.dto.UserPermissionDto
 


### PR DESCRIPTION
Add missing imports required for inline functions:
- io.github.jan.supabase.postgrest.from
- io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder

These imports are needed because inline functions from BaseSupabaseRepository are expanded at call site, requiring all imports to be available.

This fixes all 'Unresolved reference' errors for from, eq, ilike, order, etc.