### PR TITLE
Use fully qualified type path for PostgrestFilterBuilder

### DIFF
--- a/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
@@ -2,7 +2,6 @@ package com.medistock.data.remote.repository
 
 
 import io.github.jan.supabase.postgrest.from
-import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
 
 import com.medistock.data.remote.dto.AuditHistoryDto
 

--- a/app/src/main/java/com/medistock/data/remote/repository/BaseSupabaseRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BaseSupabaseRepository.kt
@@ -3,7 +3,6 @@ package com.medistock.data.remote.repository
 import com.medistock.data.remote.SupabaseClientProvider
 import io.github.jan.supabase.postgrest.from
 import io.github.jan.supabase.postgrest.query.Columns
-import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
 
 /**
  * Repository de base avec les opérations CRUD communes pour toutes les tables
@@ -75,7 +74,7 @@ abstract class BaseSupabaseRepository(
      * Récupère les enregistrements avec un filtre personnalisé
      */
     suspend inline fun <reified R> getWithFilter(
-        noinline filterBlock: suspend PostgrestFilterBuilder.() -> Unit
+        noinline filterBlock: suspend io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder.() -> Unit
     ): List<R> {
         return supabase.from(tableName).select {
             filter(filterBlock)
@@ -86,7 +85,7 @@ abstract class BaseSupabaseRepository(
      * Compte le nombre d'enregistrements avec un filtre optionnel
      */
     suspend fun count(
-        filterBlock: (suspend PostgrestFilterBuilder.() -> Unit)? = null
+        filterBlock: (suspend io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder.() -> Unit)? = null
     ): Long {
         val result = if (filterBlock != null) {
             supabase.from(tableName).select(Columns.raw("count")) {

--- a/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
@@ -2,7 +2,6 @@ package com.medistock.data.remote.repository
 
 
 import io.github.jan.supabase.postgrest.from
-import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
 
 import com.medistock.data.remote.dto.*
 

--- a/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
@@ -2,7 +2,6 @@ package com.medistock.data.remote.repository
 
 
 import io.github.jan.supabase.postgrest.from
-import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
 
 import com.medistock.data.remote.dto.ProductDto
 import com.medistock.data.remote.dto.ProductPriceDto

--- a/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
@@ -2,7 +2,6 @@ package com.medistock.data.remote.repository
 
 
 import io.github.jan.supabase.postgrest.from
-import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
 
 import com.medistock.data.remote.dto.*
 

--- a/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
@@ -2,7 +2,6 @@ package com.medistock.data.remote.repository
 
 
 import io.github.jan.supabase.postgrest.from
-import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
 
 import com.medistock.data.remote.dto.*
 

--- a/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
@@ -2,7 +2,6 @@ package com.medistock.data.remote.repository
 
 
 import io.github.jan.supabase.postgrest.from
-import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
 
 import com.medistock.data.remote.dto.AppUserDto
 import com.medistock.data.remote.dto.UserPermissionDto


### PR DESCRIPTION
- Change to io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder
- Remove explicit imports from all repository files
- Use inline specification at point of use instead

This should resolve PostgrestFilterBuilder resolution errors.