### PR TITLE
Fix all import errors in repository files

### DIFF
--- a/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
@@ -1,7 +1,7 @@
 package com.medistock.data.remote.repository
 
-
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.*
 
 import com.medistock.data.remote.dto.AuditHistoryDto
 

--- a/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
@@ -1,7 +1,7 @@
 package com.medistock.data.remote.repository
 
-
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.*
 
 import com.medistock.data.remote.dto.*
 

--- a/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
@@ -1,7 +1,7 @@
 package com.medistock.data.remote.repository
 
-
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.*
 
 import com.medistock.data.remote.dto.ProductDto
 import com.medistock.data.remote.dto.ProductPriceDto

--- a/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
@@ -1,7 +1,7 @@
 package com.medistock.data.remote.repository
 
-
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.*
 
 import com.medistock.data.remote.dto.*
 

--- a/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
@@ -1,7 +1,7 @@
 package com.medistock.data.remote.repository
 
-
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.*
 
 import com.medistock.data.remote.dto.*
 

--- a/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
@@ -1,7 +1,7 @@
 package com.medistock.data.remote.repository
 
-
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.*
 
 import com.medistock.data.remote.dto.AppUserDto
 import com.medistock.data.remote.dto.UserPermissionDto


### PR DESCRIPTION
Add required imports to all repository files:
- io.github.jan.supabase.postgrest.from
- io.github.jan.supabase.postgrest.query.*

This resolves all 'Unresolved reference' errors for:
- order, limit, not, isNull (query functions)
- eq, ilike, gte, lte, lt (filter functions)
- and all other Postgrest query builder functions

All 40+ compilation errors should now be fixed.