### PR TITLE
Add missing Supabase postgrest.from import to all repository files

### DIFF
--- a/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
@@ -1,6 +1,7 @@
 package com.medistock.data.remote.repository
 
 import com.medistock.data.remote.dto.AuditHistoryDto
+import io.github.jan.supabase.postgrest.from
 
 /**
  * Repository pour l'historique d'audit

--- a/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
@@ -1,6 +1,7 @@
 package com.medistock.data.remote.repository
 
 import com.medistock.data.remote.dto.*
+import io.github.jan.supabase.postgrest.from
 
 class SiteSupabaseRepository : BaseSupabaseRepository("sites") {
     suspend fun getAllSites(): List<SiteDto> = getAll()

--- a/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
@@ -3,6 +3,7 @@ package com.medistock.data.remote.repository
 import com.medistock.data.remote.dto.ProductDto
 import com.medistock.data.remote.dto.ProductPriceDto
 import com.medistock.data.remote.dto.CurrentStockDto
+import io.github.jan.supabase.postgrest.from
 
 class ProductSupabaseRepository : BaseSupabaseRepository("products") {
     suspend fun getAllProducts(): List<ProductDto> = getAll()

--- a/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
@@ -1,6 +1,7 @@
 package com.medistock.data.remote.repository
 
 import com.medistock.data.remote.dto.*
+import io.github.jan.supabase.postgrest.from
 
 class SaleSupabaseRepository : BaseSupabaseRepository("sales") {
     suspend fun getAllSales(): List<SaleDto> = getAll()

--- a/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
@@ -1,6 +1,7 @@
 package com.medistock.data.remote.repository
 
 import com.medistock.data.remote.dto.*
+import io.github.jan.supabase.postgrest.from
 
 class PurchaseBatchSupabaseRepository : BaseSupabaseRepository("purchase_batches") {
     suspend fun getAllBatches(): List<PurchaseBatchDto> = getAll()

--- a/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
@@ -2,6 +2,7 @@ package com.medistock.data.remote.repository
 
 import com.medistock.data.remote.dto.AppUserDto
 import com.medistock.data.remote.dto.UserPermissionDto
+import io.github.jan.supabase.postgrest.from
 
 class UserSupabaseRepository : BaseSupabaseRepository("app_users") {
     suspend fun getAllUsers(): List<AppUserDto> = getAll()


### PR DESCRIPTION
Fixed compilation errors by adding the required import statement to all repository files that use supabase.from() directly in their custom query methods. The inline functions in BaseSupabaseRepository work correctly, but child repositories need their own import for the from() extension function.

Files updated:
- AuditRepository.kt
- BasicRepositories.kt
- ProductRepositories.kt
- SalesRepositories.kt
- StockRepositories.kt
- UserRepositories.kt