### PR TITLE
Fix Supabase order() function syntax across all repository files

### DIFF
--- a/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
@@ -2,6 +2,7 @@ package com.medistock.data.remote.repository
 
 import com.medistock.data.remote.dto.AuditHistoryDto
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Order
 
 /**
  * Repository pour l'historique d'audit
@@ -23,7 +24,7 @@ class AuditHistorySupabaseRepository : BaseSupabaseRepository("audit_history") {
                 eq("entity_type", entityType)
                 eq("entity_id", entityId)
             }
-            order("changed_at", ascending = false)
+            order(column = "changed_at", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -35,7 +36,7 @@ class AuditHistorySupabaseRepository : BaseSupabaseRepository("audit_history") {
             filter {
                 eq("changed_by", username)
             }
-            order("changed_at", ascending = false)
+            order(column = "changed_at", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -47,7 +48,7 @@ class AuditHistorySupabaseRepository : BaseSupabaseRepository("audit_history") {
             filter {
                 eq("site_id", siteId)
             }
-            order("changed_at", ascending = false)
+            order(column = "changed_at", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -59,7 +60,7 @@ class AuditHistorySupabaseRepository : BaseSupabaseRepository("audit_history") {
             filter {
                 eq("action_type", actionType)
             }
-            order("changed_at", ascending = false)
+            order(column = "changed_at", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -79,7 +80,7 @@ class AuditHistorySupabaseRepository : BaseSupabaseRepository("audit_history") {
                     eq("entity_type", entityType)
                 }
             }
-            order("changed_at", ascending = false)
+            order(column = "changed_at", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -97,7 +98,7 @@ class AuditHistorySupabaseRepository : BaseSupabaseRepository("audit_history") {
                 eq("entity_id", entityId)
                 eq("field_name", fieldName)
             }
-            order("changed_at", ascending = false)
+            order(column = "changed_at", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -106,7 +107,7 @@ class AuditHistorySupabaseRepository : BaseSupabaseRepository("audit_history") {
      */
     suspend fun getRecentAuditHistory(limit: Int = 50): List<AuditHistoryDto> {
         return supabase.from(tableName).select {
-            order("changed_at", ascending = false)
+            order(column = "changed_at", order = Order.DESCENDING)
             limit(limit.toLong())
         }.decodeList()
     }

--- a/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
@@ -2,6 +2,7 @@ package com.medistock.data.remote.repository
 
 import com.medistock.data.remote.dto.*
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Order
 
 class SiteSupabaseRepository : BaseSupabaseRepository("sites") {
     suspend fun getAllSites(): List<SiteDto> = getAll()
@@ -46,7 +47,7 @@ class PackagingTypeSupabaseRepository : BaseSupabaseRepository("packaging_types"
 
     suspend fun getPackagingTypesByOrder(): List<PackagingTypeDto> {
         return supabase.from(tableName).select {
-            order("display_order")
+            order(column = "display_order", order = Order.ASCENDING)
         }.decodeList()
     }
 }

--- a/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
@@ -4,6 +4,7 @@ import com.medistock.data.remote.dto.ProductDto
 import com.medistock.data.remote.dto.ProductPriceDto
 import com.medistock.data.remote.dto.CurrentStockDto
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Order
 
 class ProductSupabaseRepository : BaseSupabaseRepository("products") {
     suspend fun getAllProducts(): List<ProductDto> = getAll()
@@ -47,7 +48,7 @@ class ProductPriceSupabaseRepository : BaseSupabaseRepository("product_prices") 
     suspend fun getPriceHistoryByProduct(productId: Long): List<ProductPriceDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
-            order("effective_date", ascending = false)
+            order(column = "effective_date", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -58,7 +59,7 @@ class ProductPriceSupabaseRepository : BaseSupabaseRepository("product_prices") 
                 eq("product_id", productId)
                 lte("effective_date", now)
             }
-            order("effective_date", ascending = false)
+            order(column = "effective_date", order = Order.DESCENDING)
             limit(1)
         }.decodeList<ProductPriceDto>().firstOrNull()
     }

--- a/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
@@ -2,6 +2,7 @@ package com.medistock.data.remote.repository
 
 import com.medistock.data.remote.dto.*
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Order
 
 class SaleSupabaseRepository : BaseSupabaseRepository("sales") {
     suspend fun getAllSales(): List<SaleDto> = getAll()
@@ -13,14 +14,14 @@ class SaleSupabaseRepository : BaseSupabaseRepository("sales") {
     suspend fun getSalesBySite(siteId: Long): List<SaleDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
     suspend fun getSalesByCustomer(customerId: Long): List<SaleDto> {
         return supabase.from(tableName).select {
             filter { eq("customer_id", customerId) }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -37,14 +38,14 @@ class SaleSupabaseRepository : BaseSupabaseRepository("sales") {
                     eq("site_id", siteId)
                 }
             }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
     suspend fun searchByCustomerName(customerName: String): List<SaleDto> {
         return supabase.from(tableName).select {
             filter { ilike("customer_name", "%$customerName%") }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -95,7 +96,7 @@ class SaleBatchAllocationSupabaseRepository : BaseSupabaseRepository("sale_batch
     suspend fun getAllocationsByBatch(batchId: Long): List<SaleBatchAllocationDto> {
         return supabase.from(tableName).select {
             filter { eq("batch_id", batchId) }
-            order("created_at", ascending = false)
+            order(column = "created_at", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -114,21 +115,21 @@ class ProductSaleSupabaseRepository : BaseSupabaseRepository("product_sales") {
     suspend fun getProductSalesByProduct(productId: Long): List<ProductSaleDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
     suspend fun getProductSalesBySite(siteId: Long): List<ProductSaleDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
     suspend fun getProductSalesByFarmer(farmerName: String): List<ProductSaleDto> {
         return supabase.from(tableName).select {
             filter { ilike("farmer_name", "%$farmerName%") }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 }

--- a/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
@@ -2,6 +2,7 @@ package com.medistock.data.remote.repository
 
 import com.medistock.data.remote.dto.*
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Order
 
 class PurchaseBatchSupabaseRepository : BaseSupabaseRepository("purchase_batches") {
     suspend fun getAllBatches(): List<PurchaseBatchDto> = getAll()
@@ -13,7 +14,7 @@ class PurchaseBatchSupabaseRepository : BaseSupabaseRepository("purchase_batches
     suspend fun getBatchesByProduct(productId: Long): List<PurchaseBatchDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
-            order("purchase_date", ascending = true)
+            order(column = "purchase_date", order = Order.ASCENDING)
         }.decodeList()
     }
 
@@ -23,7 +24,7 @@ class PurchaseBatchSupabaseRepository : BaseSupabaseRepository("purchase_batches
                 eq("product_id", productId)
                 eq("is_exhausted", false)
             }
-            order("purchase_date", ascending = true)
+            order(column = "purchase_date", order = Order.ASCENDING)
         }.decodeList()
     }
 
@@ -40,7 +41,7 @@ class PurchaseBatchSupabaseRepository : BaseSupabaseRepository("purchase_batches
                 eq("is_exhausted", false)
                 lte("expiry_date", thresholdDate)
             }
-            order("expiry_date", ascending = true)
+            order(column = "expiry_date", order = Order.ASCENDING)
         }.decodeList()
     }
 
@@ -59,14 +60,14 @@ class StockMovementSupabaseRepository : BaseSupabaseRepository("stock_movements"
     suspend fun getMovementsByProduct(productId: Long): List<StockMovementDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
     suspend fun getMovementsBySite(siteId: Long): List<StockMovementDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -78,7 +79,7 @@ class StockMovementSupabaseRepository : BaseSupabaseRepository("stock_movements"
                     eq("site_id", siteId)
                 }
             }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -95,7 +96,7 @@ class StockMovementSupabaseRepository : BaseSupabaseRepository("stock_movements"
                     eq("site_id", siteId)
                 }
             }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 }
@@ -110,14 +111,14 @@ class InventorySupabaseRepository : BaseSupabaseRepository("inventories") {
     suspend fun getInventoriesByProduct(productId: Long): List<InventoryDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
-            order("count_date", ascending = false)
+            order(column = "count_date", order = Order.DESCENDING)
         }.decodeList()
     }
 
     suspend fun getInventoriesBySite(siteId: Long): List<InventoryDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
-            order("count_date", ascending = false)
+            order(column = "count_date", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -129,7 +130,7 @@ class InventorySupabaseRepository : BaseSupabaseRepository("inventories") {
                     eq("site_id", siteId)
                 }
             }
-            order("count_date", ascending = false)
+            order(column = "count_date", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -139,7 +140,7 @@ class InventorySupabaseRepository : BaseSupabaseRepository("inventories") {
                 eq("product_id", productId)
                 eq("site_id", siteId)
             }
-            order("count_date", ascending = false)
+            order(column = "count_date", order = Order.DESCENDING)
             limit(1)
         }.decodeList<InventoryDto>().firstOrNull()
     }
@@ -155,21 +156,21 @@ class ProductTransferSupabaseRepository : BaseSupabaseRepository("product_transf
     suspend fun getTransfersFromSite(siteId: Long): List<ProductTransferDto> {
         return supabase.from(tableName).select {
             filter { eq("from_site_id", siteId) }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
     suspend fun getTransfersToSite(siteId: Long): List<ProductTransferDto> {
         return supabase.from(tableName).select {
             filter { eq("to_site_id", siteId) }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
     suspend fun getTransfersByProduct(productId: Long): List<ProductTransferDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
@@ -179,7 +180,7 @@ class ProductTransferSupabaseRepository : BaseSupabaseRepository("product_transf
                 eq("from_site_id", fromSiteId)
                 eq("to_site_id", toSiteId)
             }
-            order("date", ascending = false)
+            order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 }


### PR DESCRIPTION
Corrected the order() function calls to use the proper Supabase Kotlin syntax with named parameters: order(column = "...", order = Order.ASCENDING/DESCENDING) instead of the incorrect order("...", ascending = true/false).

Added import io.github.jan.supabase.postgrest.query.Order to all repository files that use the order() function.

Changes:
- AuditRepository.kt: Fixed 7 order() calls for changed_at column
- ProductRepositories.kt: Fixed 2 order() calls for effective_date column
- SalesRepositories.kt: Fixed 8 order() calls for date and created_at columns
- StockRepositories.kt: Fixed 11 order() calls for purchase_date, expiry_date, date, and count_date columns
- BasicRepositories.kt: Fixed 1 order() call for display_order column

This resolves all "Cannot find a parameter with this name: ascending" and "No value passed for parameter 'order'" compilation errors.