### PR TITLE
Upgrade Supabase SDK from 2.0.0 to 3.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     implementation "at.favre.lib:bcrypt:0.10.2"
 
     // Supabase
-    def supabase_version = "2.0.0"
+    def supabase_version = "3.0.2"
     implementation "io.github.jan-tennert.supabase:postgrest-kt:$supabase_version"
     implementation "io.github.jan-tennert.supabase:realtime-kt:$supabase_version"
 


### PR DESCRIPTION
Updated to version 3.0.2 which supports passing serializable objects directly to insert() and update() methods, resolving type mismatch errors in BaseSupabaseRepository.

Version 3.x added support for JsonObject/JsonElement in insert/upsert/update methods, which allows our generic CRUD methods to work correctly.