### PR TITLE
Fix insert() and update() syntax to use DSL blocks correctly

### DIFF
--- a/app/src/main/java/com/medistock/data/remote/repository/BaseSupabaseRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BaseSupabaseRepository.kt
@@ -41,21 +41,21 @@ abstract class BaseSupabaseRepository(
      * Crée un nouvel enregistrement
      */
     suspend inline fun <reified R : Any> create(item: R): R {
-        return supabase.from(tableName)
-            .insert(item)
-            .select()
-            .decodeSingle()
+        return supabase.from(tableName).insert(item) {
+            select()
+        }.decodeSingle()
     }
 
     /**
      * Met à jour un enregistrement
      */
     suspend inline fun <reified R : Any> update(id: Long, item: R): R {
-        return supabase.from(tableName)
-            .update(item)
-            .select()
-            .eq("id", id)
-            .decodeSingle()
+        return supabase.from(tableName).update(item) {
+            select()
+            filter {
+                eq("id", id)
+            }
+        }.decodeSingle()
     }
 
     /**


### PR DESCRIPTION
Corrected the syntax to call select() within DSL lambda blocks instead of method chaining, which is the proper Supabase Kotlin SDK syntax:
- insert(item) { select() } instead of insert(item).select()
- update(item) { select(); filter { ... } } instead of update(item).select()

This resolves "Unresolved reference 'select'" compilation errors.