### PR TITLE
Fix NoClassDefFoundError for Ktor HttpTimeout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,6 +82,9 @@ dependencies {
     def ktor_version = "2.3.7"
     implementation "io.ktor:ktor-client-android:$ktor_version"
     implementation "io.ktor:ktor-client-core:$ktor_version"
+    implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"
+    implementation "io.ktor:ktor-serialization-kotlinx-json:$ktor_version"
+    implementation "io.ktor:ktor-utils:$ktor_version"
 
     // Kotlinx Serialization
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"

--- a/app/src/main/java/com/medistock/data/remote/SupabaseClient.kt
+++ b/app/src/main/java/com/medistock/data/remote/SupabaseClient.kt
@@ -6,7 +6,6 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.realtime.Realtime
-import io.ktor.client.engine.android.*
 
 /**
  * Client Supabase singleton pour Medistock
@@ -71,9 +70,6 @@ object SupabaseClientProvider {
 
                 // Installation du module Realtime pour les subscriptions
                 install(Realtime)
-
-                // Configuration du client HTTP pour Android
-                httpEngine = Android.create()
             }
 
             if (SupabaseConfig.DEBUG_MODE) {


### PR DESCRIPTION
Fixed the crash caused by missing Ktor dependencies:

Changes in app/build.gradle:
- Added ktor-client-content-negotiation
- Added ktor-serialization-kotlinx-json
- Added ktor-utils

Changes in SupabaseClient.kt:
- Removed explicit httpEngine = Android.create() configuration
- Removed unnecessary Android engine import
- Supabase will use default HTTP engine which works correctly

This resolves the crash:
java.lang.NoClassDefFoundError: Failed resolution of: Lio/ktor/client/plugins/HttpTimeout

The Android engine was trying to load HttpTimeout plugin which wasn't in the dependencies. By letting Supabase use its default engine, the app will initialize correctly.