### PR TITLE
Replace Ktor Android engine with OkHttp to fix HttpTimeout crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,13 +78,12 @@ dependencies {
     implementation "io.github.jan-tennert.supabase:postgrest-kt:$supabase_version"
     implementation "io.github.jan-tennert.supabase:realtime-kt:$supabase_version"
 
-    // Ktor client for Supabase
+    // Ktor client for Supabase (using OkHttp engine instead of Android)
     def ktor_version = "2.3.7"
-    implementation "io.ktor:ktor-client-android:$ktor_version"
     implementation "io.ktor:ktor-client-core:$ktor_version"
+    implementation "io.ktor:ktor-client-okhttp:$ktor_version"
     implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"
     implementation "io.ktor:ktor-serialization-kotlinx-json:$ktor_version"
-    implementation "io.ktor:ktor-utils:$ktor_version"
 
     // Kotlinx Serialization
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"


### PR DESCRIPTION
The Android engine was trying to load HttpTimeout plugin which wasn't available in the classpath, causing NoClassDefFoundError.

Changed from ktor-client-android to ktor-client-okhttp:
- Removed ktor-client-android
- Removed ktor-utils (not needed)
- Added ktor-client-okhttp (more stable, better Android support)

OkHttp is the recommended HTTP engine for Android apps and doesn't have the HttpTimeout dependency issue.

This should resolve:
java.lang.NoClassDefFoundError: Failed resolution of: Lio/ktor/client/plugins/HttpTimeout