### PR TITLE
Add Ktor BOM to ensure all dependencies are version-aligned

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,12 +78,13 @@ dependencies {
     implementation "io.github.jan-tennert.supabase:postgrest-kt:$supabase_version"
     implementation "io.github.jan-tennert.supabase:realtime-kt:$supabase_version"
 
-    // Ktor client for Supabase
+    // Ktor client for Supabase with BOM for version alignment
     def ktor_version = "2.3.12"
-    implementation "io.ktor:ktor-client-core:$ktor_version"
-    implementation "io.ktor:ktor-client-okhttp:$ktor_version"
-    implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"
-    implementation "io.ktor:ktor-serialization-kotlinx-json:$ktor_version"
+    implementation platform("io.ktor:ktor-bom:$ktor_version")
+    implementation "io.ktor:ktor-client-core"
+    implementation "io.ktor:ktor-client-okhttp"
+    implementation "io.ktor:ktor-client-content-negotiation"
+    implementation "io.ktor:ktor-serialization-kotlinx-json"
 
     // Kotlinx Serialization
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"


### PR DESCRIPTION
Added Ktor BOM (Bill of Materials) which ensures all Ktor dependencies use compatible versions and include all necessary transitive dependencies like HttpTimeout.

The BOM manages version alignment automatically, removing version numbers from individual Ktor dependencies while ensuring they're all compatible.

This should finally resolve the HttpTimeout ClassNotFoundException by ensuring the plugin is properly included in all Ktor modules.