### PR TITLE
Fix Supabase version to 2.2.2 (2.7.1 doesn't exist)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,13 +73,13 @@ dependencies {
     // BCrypt for password hashing
     implementation "at.favre.lib:bcrypt:0.10.2"
 
-    // Supabase - Downgraded to 2.x for better Ktor compatibility
-    def supabase_version = "2.7.1"
+    // Supabase - Using stable 2.x version (2.2.2) for better Ktor compatibility
+    def supabase_version = "2.2.2"
     implementation "io.github.jan-tennert.supabase:postgrest-kt:$supabase_version"
     implementation "io.github.jan-tennert.supabase:realtime-kt:$supabase_version"
 
-    // Ktor client for Supabase - Using 2.3.7 compatible with Supabase 2.x
-    def ktor_version = "2.3.7"
+    // Ktor client for Supabase - Using 2.3.4 compatible with Supabase 2.2.2
+    def ktor_version = "2.3.4"
     implementation "io.ktor:ktor-client-core:$ktor_version"
     implementation "io.ktor:ktor-client-android:$ktor_version"
     implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"

--- a/app/src/main/java/com/medistock/MedistockApplication.kt
+++ b/app/src/main/java/com/medistock/MedistockApplication.kt
@@ -13,10 +13,10 @@ class MedistockApplication : Application() {
         super.onCreate()
 
         // Initialiser le client Supabase au démarrage de l'app
-        // Version downgradée à Supabase 2.7.1 + Ktor 2.3.7 pour résoudre le problème HttpTimeout
+        // Version downgradée à Supabase 2.2.2 + Ktor 2.3.4 pour résoudre le problème HttpTimeout
         try {
             SupabaseClientProvider.initialize(this)
-            println("✅ Application démarrée avec Supabase 2.7.1")
+            println("✅ Application démarrée avec Supabase 2.2.2")
         } catch (e: IllegalStateException) {
             // Les credentials Supabase ne sont pas encore configurés
             println("⚠️ Supabase non configuré: ${e.message}")


### PR DESCRIPTION
The version 2.7.1 does not exist in Maven repositories. Using the stable version 2.2.2 which was released in March 2024.

Changes:
- Supabase: 2.7.1 (invalid) → 2.2.2 (stable)
- Ktor: 2.3.7 → 2.3.4 (compatible with Supabase 2.2.2)

Source: Maven Central repository
https://repo1.maven.org/maven2/io/github/jan-tennert/supabase/supabase-kt/2.2.2/