### PR TITLE
Fix sync local → remote using upsert instead of update

### DIFF
--- a/app/src/main/java/com/medistock/data/remote/repository/BaseSupabaseRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BaseSupabaseRepository.kt
@@ -59,6 +59,16 @@ abstract class BaseSupabaseRepository(
     }
 
     /**
+     * Upsert (Insert or Update) - Crée si n'existe pas, met à jour sinon
+     * Utilise la clé primaire 'id' pour détecter les conflits
+     */
+    suspend inline fun <reified R : Any> upsert(item: R): R {
+        return supabase.from(tableName).upsert(item) {
+            select()
+        }.decodeSingle()
+    }
+
+    /**
      * Supprime un enregistrement
      */
     suspend fun delete(id: Long) {

--- a/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
@@ -9,6 +9,7 @@ class SiteSupabaseRepository : BaseSupabaseRepository("sites") {
     suspend fun getSiteById(id: Long): SiteDto? = getById(id)
     suspend fun createSite(site: SiteDto): SiteDto = create(site)
     suspend fun updateSite(id: Long, site: SiteDto): SiteDto = update(id, site)
+    suspend fun upsertSite(site: SiteDto): SiteDto = upsert(site)
     suspend fun deleteSite(id: Long) = delete(id)
 
     suspend fun searchByName(name: String): List<SiteDto> {
@@ -23,6 +24,7 @@ class CategorySupabaseRepository : BaseSupabaseRepository("categories") {
     suspend fun getCategoryById(id: Long): CategoryDto? = getById(id)
     suspend fun createCategory(category: CategoryDto): CategoryDto = create(category)
     suspend fun updateCategory(id: Long, category: CategoryDto): CategoryDto = update(id, category)
+    suspend fun upsertCategory(category: CategoryDto): CategoryDto = upsert(category)
     suspend fun deleteCategory(id: Long) = delete(id)
 
     suspend fun searchByName(name: String): List<CategoryDto> {
@@ -37,6 +39,7 @@ class PackagingTypeSupabaseRepository : BaseSupabaseRepository("packaging_types"
     suspend fun getPackagingTypeById(id: Long): PackagingTypeDto? = getById(id)
     suspend fun createPackagingType(packagingType: PackagingTypeDto): PackagingTypeDto = create(packagingType)
     suspend fun updatePackagingType(id: Long, packagingType: PackagingTypeDto): PackagingTypeDto = update(id, packagingType)
+    suspend fun upsertPackagingType(packagingType: PackagingTypeDto): PackagingTypeDto = upsert(packagingType)
     suspend fun deletePackagingType(id: Long) = delete(id)
 
     suspend fun getActivePackagingTypes(): List<PackagingTypeDto> {
@@ -57,6 +60,7 @@ class CustomerSupabaseRepository : BaseSupabaseRepository("customers") {
     suspend fun getCustomerById(id: Long): CustomerDto? = getById(id)
     suspend fun createCustomer(customer: CustomerDto): CustomerDto = create(customer)
     suspend fun updateCustomer(id: Long, customer: CustomerDto): CustomerDto = update(id, customer)
+    suspend fun upsertCustomer(customer: CustomerDto): CustomerDto = upsert(customer)
     suspend fun deleteCustomer(id: Long) = delete(id)
 
     suspend fun getCustomersBySite(siteId: Long): List<CustomerDto> {

--- a/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
@@ -11,6 +11,7 @@ class ProductSupabaseRepository : BaseSupabaseRepository("products") {
     suspend fun getProductById(id: Long): ProductDto? = getById(id)
     suspend fun createProduct(product: ProductDto): ProductDto = create(product)
     suspend fun updateProduct(id: Long, product: ProductDto): ProductDto = update(id, product)
+    suspend fun upsertProduct(product: ProductDto): ProductDto = upsert(product)
     suspend fun deleteProduct(id: Long) = delete(id)
 
     suspend fun getProductsBySite(siteId: Long): List<ProductDto> {

--- a/app/src/main/java/com/medistock/data/sync/SyncManager.kt
+++ b/app/src/main/java/com/medistock/data/sync/SyncManager.kt
@@ -116,13 +116,8 @@ class SyncManager(
             localSites.forEach { site ->
                 try {
                     val dto = site.toDto()
-                    if (site.id == 0L) {
-                        // Nouveau site - créer
-                        siteRepo.createSite(dto)
-                    } else {
-                        // Mettre à jour
-                        siteRepo.updateSite(site.id, dto)
-                    }
+                    // Upsert: insère si nouveau, met à jour sinon
+                    siteRepo.upsertSite(dto)
                 } catch (e: Exception) {
                     onError?.invoke("Site: ${site.name}", e)
                 }
@@ -156,11 +151,8 @@ class SyncManager(
             localTypes.forEach { type ->
                 try {
                     val dto = type.toDto()
-                    if (type.id == 0L) {
-                        packagingTypeRepo.createPackagingType(dto)
-                    } else {
-                        packagingTypeRepo.updatePackagingType(type.id, dto)
-                    }
+                    // Upsert: insère si nouveau, met à jour sinon
+                    packagingTypeRepo.upsertPackagingType(dto)
                 } catch (e: Exception) {
                     onError?.invoke("PackagingType: ${type.name}", e)
                 }
@@ -194,11 +186,8 @@ class SyncManager(
             localCategories.forEach { category ->
                 try {
                     val dto = category.toDto()
-                    if (category.id == 0L) {
-                        categoryRepo.createCategory(dto)
-                    } else {
-                        categoryRepo.updateCategory(category.id, dto)
-                    }
+                    // Upsert: insère si nouveau, met à jour sinon
+                    categoryRepo.upsertCategory(dto)
                 } catch (e: Exception) {
                     onError?.invoke("Category: ${category.name}", e)
                 }
@@ -232,11 +221,8 @@ class SyncManager(
             localProducts.forEach { product ->
                 try {
                     val dto = product.toDto()
-                    if (product.id == 0L) {
-                        productRepo.createProduct(dto)
-                    } else {
-                        productRepo.updateProduct(product.id, dto)
-                    }
+                    // Upsert: insère si nouveau, met à jour sinon
+                    productRepo.upsertProduct(dto)
                 } catch (e: Exception) {
                     onError?.invoke("Product: ${product.name}", e)
                 }
@@ -270,11 +256,8 @@ class SyncManager(
             localCustomers.forEach { customer ->
                 try {
                     val dto = customer.toDto()
-                    if (customer.id == 0L) {
-                        customerRepo.createCustomer(dto)
-                    } else {
-                        customerRepo.updateCustomer(customer.id, dto)
-                    }
+                    // Upsert: insère si nouveau, met à jour sinon
+                    customerRepo.upsertCustomer(dto)
                 } catch (e: Exception) {
                     onError?.invoke("Customer: ${customer.name}", e)
                 }


### PR DESCRIPTION
Previous logic checked if ID == 0 to decide between insert/update, but Room auto-generates IDs (1, 2, 3...), so newly created items always had ID > 0. This caused the sync to try updating non-existent records in Supabase instead of inserting them.

Changes:
1. Added upsert() method to BaseSupabaseRepository
   - Uses Supabase UPSERT (INSERT ON CONFLICT UPDATE)
   - Automatically inserts if new, updates if exists

2. Added upsert methods to all repositories:
   - SiteSupabaseRepository.upsertSite()
   - CategorySupabaseRepository.upsertCategory()
   - PackagingTypeSupabaseRepository.upsertPackagingType()
   - ProductSupabaseRepository.upsertProduct()
   - CustomerSupabaseRepository.upsertCustomer()

3. Updated SyncManager to use upsert for all sync...ToRemote():
   - syncSitesToRemote()
   - syncCategoriesToRemote()
   - syncPackagingTypesToRemote()
   - syncProductsToRemote()
   - syncCustomersToRemote()

Now when you create a Site/Product/etc in the app and click "📤 Envoyer...", it correctly uploads to Supabase!