### PR TITLE
Migrate integer IDs to UUIDs (app + Supabase)

### DIFF
--- a/app/src/main/java/com/medistock/data/dao/AuditHistoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/AuditHistoryDao.kt
@@ -16,13 +16,13 @@ interface AuditHistoryDao {
     fun getByEntityType(entityType: String): Flow<List<AuditHistory>>
 
     @Query("SELECT * FROM audit_history WHERE entity_type = :entityType AND entity_id = :entityId ORDER BY changed_at DESC")
-    fun getByEntity(entityType: String, entityId: Long): Flow<List<AuditHistory>>
+    fun getByEntity(entityType: String, entityId: String): Flow<List<AuditHistory>>
 
     @Query("SELECT * FROM audit_history WHERE changed_by = :username ORDER BY changed_at DESC")
     fun getByUser(username: String): Flow<List<AuditHistory>>
 
     @Query("SELECT * FROM audit_history WHERE site_id = :siteId ORDER BY changed_at DESC")
-    fun getBySite(siteId: Long): Flow<List<AuditHistory>>
+    fun getBySite(siteId: String): Flow<List<AuditHistory>>
 
     @Query("SELECT * FROM audit_history WHERE changed_at >= :startTime AND changed_at <= :endTime ORDER BY changed_at DESC")
     fun getByDateRange(startTime: Long, endTime: Long): Flow<List<AuditHistory>>
@@ -42,7 +42,7 @@ interface AuditHistoryDao {
         entityType: String?,
         actionType: String?,
         username: String?,
-        siteId: Long?,
+        siteId: String?,
         startTime: Long?,
         endTime: Long?,
         limit: Int = 100,

--- a/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/CategoryDao.kt
@@ -20,5 +20,5 @@ interface CategoryDao {
     fun getAll(): Flow<List<Category>>
 
     @Query("SELECT * FROM categories WHERE id = :categoryId LIMIT 1")
-    fun getById(categoryId: Long): Flow<Category?>
+    fun getById(categoryId: String): Flow<Category?>
 }

--- a/app/src/main/java/com/medistock/data/dao/CustomerDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/CustomerDao.kt
@@ -16,20 +16,20 @@ interface CustomerDao {
     fun delete(customer: Customer)
 
     @Query("SELECT * FROM customers WHERE id = :id")
-    fun getById(id: Long): Flow<Customer?>
+    fun getById(id: String): Flow<Customer?>
 
     @Query("SELECT * FROM customers ORDER BY name ASC")
     fun getAll(): Flow<List<Customer>>
 
     @Query("SELECT * FROM customers WHERE siteId = :siteId ORDER BY name ASC")
-    fun getAllForSite(siteId: Long): Flow<List<Customer>>
+    fun getAllForSite(siteId: String): Flow<List<Customer>>
 
     @Query("SELECT * FROM customers WHERE siteId = :siteId AND name LIKE '%' || :query || '%' ORDER BY name ASC")
-    fun searchByName(siteId: Long, query: String): Flow<List<Customer>>
+    fun searchByName(siteId: String, query: String): Flow<List<Customer>>
 
     @Query("SELECT * FROM customers WHERE siteId = :siteId AND (name LIKE '%' || :query || '%' OR phone LIKE '%' || :query || '%') ORDER BY name ASC")
-    fun search(siteId: Long, query: String): Flow<List<Customer>>
+    fun search(siteId: String, query: String): Flow<List<Customer>>
 
     @Query("DELETE FROM customers WHERE id = :id")
-    fun deleteById(id: Long)
+    fun deleteById(id: String)
 }

--- a/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/InventoryDao.kt
@@ -13,13 +13,13 @@ interface InventoryDao {
     fun update(inventory: Inventory)
 
     @Query("SELECT * FROM inventories WHERE id = :inventoryId")
-    fun getById(inventoryId: Long): Flow<Inventory?>
+    fun getById(inventoryId: String): Flow<Inventory?>
 
     @Query("SELECT * FROM inventories WHERE productId = :productId AND siteId = :siteId ORDER BY countDate DESC")
-    fun getInventoriesForProduct(productId: Long, siteId: Long): Flow<List<Inventory>>
+    fun getInventoriesForProduct(productId: String, siteId: String): Flow<List<Inventory>>
 
     @Query("SELECT * FROM inventories WHERE siteId = :siteId ORDER BY countDate DESC")
-    fun getInventoriesForSite(siteId: Long): Flow<List<Inventory>>
+    fun getInventoriesForSite(siteId: String): Flow<List<Inventory>>
 
     @Query("SELECT * FROM inventories ORDER BY countDate DESC LIMIT :limit")
     fun getRecentInventories(limit: Int = 50): Flow<List<Inventory>>
@@ -33,7 +33,7 @@ interface InventoryDao {
         AND discrepancy != 0
         ORDER BY countDate DESC
     """)
-    fun getInventoriesWithDiscrepancies(siteId: Long): Flow<List<Inventory>>
+    fun getInventoriesWithDiscrepancies(siteId: String): Flow<List<Inventory>>
 
     /**
      * Get total discrepancy value for a site.
@@ -43,8 +43,8 @@ interface InventoryDao {
         WHERE siteId = :siteId
         AND countDate >= :startDate
     """)
-    fun getTotalDiscrepancy(siteId: Long, startDate: Long): Double?
+    fun getTotalDiscrepancy(siteId: String, startDate: Long): Double?
 
     @Query("DELETE FROM inventories WHERE id = :inventoryId")
-    fun deleteById(inventoryId: Long)
+    fun deleteById(inventoryId: String)
 }

--- a/app/src/main/java/com/medistock/data/dao/PackagingTypeDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/PackagingTypeDao.kt
@@ -14,10 +14,10 @@ interface PackagingTypeDao {
     fun getAll(): Flow<List<PackagingType>>
 
     @Query("SELECT * FROM packaging_types WHERE id = :id")
-    fun getById(id: Long): Flow<PackagingType?>
+    fun getById(id: String): Flow<PackagingType?>
 
     @Query("SELECT * FROM packaging_types WHERE id = :id")
-    fun getByIdSync(id: Long): PackagingType?
+    fun getByIdSync(id: String): PackagingType?
 
     @Query("SELECT * FROM packaging_types WHERE name = :name LIMIT 1")
     fun getByName(name: String): PackagingType?
@@ -32,14 +32,14 @@ interface PackagingTypeDao {
     fun delete(packagingType: PackagingType)
 
     @Query("UPDATE packaging_types SET isActive = 0 WHERE id = :id")
-    fun deactivate(id: Long)
+    fun deactivate(id: String)
 
     @Query("UPDATE packaging_types SET isActive = 1 WHERE id = :id")
-    fun activate(id: Long)
+    fun activate(id: String)
 
     @Query("SELECT COUNT(*) FROM packaging_types WHERE isActive = 1")
     fun getActiveCount(): Int
 
     @Query("SELECT EXISTS(SELECT 1 FROM products WHERE packagingTypeId = :packagingTypeId LIMIT 1)")
-    fun isUsedByProducts(packagingTypeId: Long): Boolean
+    fun isUsedByProducts(packagingTypeId: String): Boolean
 }

--- a/app/src/main/java/com/medistock/data/dao/ProductDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductDao.kt
@@ -20,10 +20,10 @@ interface ProductDao {
     fun getAll(): Flow<List<Product>>
 
     @Query("SELECT * FROM products WHERE id = :productId LIMIT 1")
-    fun getById(productId: Long): Flow<Product?>
+    fun getById(productId: String): Flow<Product?>
 
     @Query("SELECT * FROM products WHERE siteId = :siteId")
-    fun getProductsForSite(siteId: Long): Flow<List<Product>>
+    fun getProductsForSite(siteId: String): Flow<List<Product>>
 
     @Query("""
         SELECT p.id, p.name, p.unit, p.categoryId, c.name as categoryName,
@@ -42,5 +42,5 @@ interface ProductDao {
         LEFT JOIN categories c ON p.categoryId = c.id
         WHERE p.siteId = :siteId
     """)
-    fun getProductsWithCategoryForSite(siteId: Long): Flow<List<ProductWithCategory>>
+    fun getProductsWithCategoryForSite(siteId: String): Flow<List<ProductWithCategory>>
 }

--- a/app/src/main/java/com/medistock/data/dao/ProductPriceDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductPriceDao.kt
@@ -2,7 +2,6 @@ package com.medistock.data.dao
 
 import androidx.room.*
 import com.medistock.data.entities.ProductPrice
-import com.medistock.data.entities.ProductSale
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -14,5 +13,5 @@ interface ProductPriceDao {
     fun getAll(): Flow<List<ProductPrice>>
 
     @Query("SELECT * FROM product_prices WHERE productId = :productId ORDER BY effectiveDate DESC LIMIT 1")
-    fun getLatestPrice(productId: Long): Flow<ProductPrice?>
+    fun getLatestPrice(productId: String): Flow<ProductPrice?>
 }

--- a/app/src/main/java/com/medistock/data/dao/ProductSaleDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductSaleDao.kt
@@ -2,7 +2,6 @@ package com.medistock.data.dao
 
 import androidx.room.*
 import com.medistock.data.entities.ProductSale
-import com.medistock.data.entities.StockMovement
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -14,8 +13,8 @@ interface ProductSaleDao {
     fun getAll(): Flow<List<ProductSale>>
 
     @Query("SELECT * FROM product_sales WHERE productId = :productId AND siteId = :siteId ORDER BY date DESC")
-    fun getSalesForProduct(productId: Long, siteId: Long): Flow<List<ProductSale>>
+    fun getSalesForProduct(productId: String, siteId: String): Flow<List<ProductSale>>
 
     @Query("SELECT * FROM product_sales WHERE siteId = :siteId ORDER BY date DESC")
-    fun getAllForSite(siteId: Long): Flow<List<ProductSale>>
+    fun getAllForSite(siteId: String): Flow<List<ProductSale>>
 }

--- a/app/src/main/java/com/medistock/data/dao/ProductTransferDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/ProductTransferDao.kt
@@ -19,11 +19,11 @@ interface ProductTransferDao {
     fun getAll(): Flow<List<ProductTransfer>>
 
     @Query("SELECT * FROM product_transfers WHERE fromSiteId = :siteId OR toSiteId = :siteId ORDER BY date DESC")
-    fun getTransfersForSite(siteId: Long): Flow<List<ProductTransfer>>
+    fun getTransfersForSite(siteId: String): Flow<List<ProductTransfer>>
 
     @Query("SELECT * FROM product_transfers WHERE id = :id")
-    fun getById(id: Long): Flow<ProductTransfer?>
+    fun getById(id: String): Flow<ProductTransfer?>
 
     @Query("SELECT * FROM product_transfers WHERE productId = :productId ORDER BY date DESC")
-    fun getTransfersForProduct(productId: Long): Flow<List<ProductTransfer>>
+    fun getTransfersForProduct(productId: String): Flow<List<ProductTransfer>>
 }

--- a/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/PurchaseBatchDao.kt
@@ -13,10 +13,10 @@ interface PurchaseBatchDao {
     fun update(batch: PurchaseBatch)
 
     @Query("SELECT * FROM purchase_batches WHERE id = :batchId")
-    fun getById(batchId: Long): Flow<PurchaseBatch?>
+    fun getById(batchId: String): Flow<PurchaseBatch?>
 
     @Query("SELECT * FROM purchase_batches WHERE productId = :productId AND siteId = :siteId ORDER BY purchaseDate ASC")
-    fun getBatchesForProduct(productId: Long, siteId: Long): Flow<List<PurchaseBatch>>
+    fun getBatchesForProduct(productId: String, siteId: String): Flow<List<PurchaseBatch>>
 
     /**
      * Get available batches (not exhausted) for FIFO consumption.
@@ -30,7 +30,7 @@ interface PurchaseBatchDao {
         AND remainingQuantity > 0
         ORDER BY purchaseDate ASC
     """)
-    fun getAvailableBatchesFIFO(productId: Long, siteId: Long): Flow<List<PurchaseBatch>>
+    fun getAvailableBatchesFIFO(productId: String, siteId: String): Flow<List<PurchaseBatch>>
 
     /**
      * Get batches expiring soon (within days threshold).
@@ -44,7 +44,7 @@ interface PurchaseBatchDao {
         AND expiryDate <= :thresholdDate
         ORDER BY expiryDate ASC
     """)
-    fun getBatchesExpiringSoon(productId: Long, siteId: Long, thresholdDate: Long): Flow<List<PurchaseBatch>>
+    fun getBatchesExpiringSoon(productId: String, siteId: String, thresholdDate: Long): Flow<List<PurchaseBatch>>
 
     /**
      * Calculate average purchase price for a product.
@@ -55,7 +55,7 @@ interface PurchaseBatchDao {
         AND siteId = :siteId
         AND isExhausted = 0
     """)
-    fun getAveragePurchasePrice(productId: Long, siteId: Long): Double?
+    fun getAveragePurchasePrice(productId: String, siteId: String): Double?
 
     /**
      * Get total remaining quantity across all batches.
@@ -66,10 +66,10 @@ interface PurchaseBatchDao {
         AND siteId = :siteId
         AND isExhausted = 0
     """)
-    fun getTotalRemainingQuantity(productId: Long, siteId: Long): Double?
+    fun getTotalRemainingQuantity(productId: String, siteId: String): Double?
 
     @Query("DELETE FROM purchase_batches WHERE id = :batchId")
-    fun deleteById(batchId: Long)
+    fun deleteById(batchId: String)
 
     /**
      * Update remaining quantity and exhausted status for a batch.
@@ -81,7 +81,7 @@ interface PurchaseBatchDao {
             updatedAt = :updatedAt
         WHERE id = :batchId
     """)
-    fun updateRemainingQuantity(batchId: Long, newQuantity: Double, updatedAt: Long): Int
+    fun updateRemainingQuantity(batchId: String, newQuantity: Double, updatedAt: Long): Int
 
     /**
      * Get available batches ordered by purchase date (FIFO) - non-Flow version for transactions.
@@ -94,5 +94,5 @@ interface PurchaseBatchDao {
         AND remainingQuantity > 0
         ORDER BY purchaseDate ASC
     """)
-    fun getAvailableBatchesFIFOSync(productId: Long, siteId: Long): List<PurchaseBatch>
+    fun getAvailableBatchesFIFOSync(productId: String, siteId: String): List<PurchaseBatch>
 }

--- a/app/src/main/java/com/medistock/data/dao/SaleBatchAllocationDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/SaleBatchAllocationDao.kt
@@ -13,17 +13,17 @@ interface SaleBatchAllocationDao {
     fun insertAll(allocations: List<SaleBatchAllocation>)
 
     @Query("SELECT * FROM sale_batch_allocations WHERE saleItemId = :saleItemId")
-    fun getAllocationsForSaleItem(saleItemId: Long): Flow<List<SaleBatchAllocation>>
+    fun getAllocationsForSaleItem(saleItemId: String): Flow<List<SaleBatchAllocation>>
 
     @Query("SELECT * FROM sale_batch_allocations WHERE batchId = :batchId")
-    fun getAllocationsForBatch(batchId: Long): Flow<List<SaleBatchAllocation>>
+    fun getAllocationsForBatch(batchId: String): Flow<List<SaleBatchAllocation>>
 
     @Query("""
         SELECT SUM(quantityAllocated) FROM sale_batch_allocations
         WHERE batchId = :batchId
     """)
-    fun getTotalAllocatedForBatch(batchId: Long): Double?
+    fun getTotalAllocatedForBatch(batchId: String): Double?
 
     @Query("DELETE FROM sale_batch_allocations WHERE saleItemId = :saleItemId")
-    fun deleteAllForSaleItem(saleItemId: Long)
+    fun deleteAllForSaleItem(saleItemId: String)
 }

--- a/app/src/main/java/com/medistock/data/dao/SaleDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/SaleDao.kt
@@ -17,19 +17,19 @@ interface SaleDao {
     fun delete(sale: Sale)
 
     @Query("SELECT * FROM sales WHERE id = :id")
-    fun getById(id: Long): Flow<Sale?>
+    fun getById(id: String): Flow<Sale?>
 
     @Query("SELECT * FROM sales WHERE siteId = :siteId ORDER BY date DESC")
-    fun getAllForSite(siteId: Long): Flow<List<Sale>>
+    fun getAllForSite(siteId: String): Flow<List<Sale>>
 
     @Transaction
     @Query("SELECT * FROM sales WHERE id = :id")
-    fun getSaleWithItems(id: Long): Flow<SaleWithItems?>
+    fun getSaleWithItems(id: String): Flow<SaleWithItems?>
 
     @Transaction
     @Query("SELECT * FROM sales WHERE siteId = :siteId ORDER BY date DESC")
-    fun getAllWithItemsForSite(siteId: Long): Flow<List<SaleWithItems>>
+    fun getAllWithItemsForSite(siteId: String): Flow<List<SaleWithItems>>
 
     @Query("DELETE FROM sales WHERE id = :id")
-    fun deleteById(id: Long)
+    fun deleteById(id: String)
 }

--- a/app/src/main/java/com/medistock/data/dao/SaleItemDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/SaleItemDao.kt
@@ -19,8 +19,8 @@ interface SaleItemDao {
     fun delete(saleItem: SaleItem)
 
     @Query("SELECT * FROM sale_items WHERE saleId = :saleId")
-    fun getItemsForSale(saleId: Long): Flow<List<SaleItem>>
+    fun getItemsForSale(saleId: String): Flow<List<SaleItem>>
 
     @Query("DELETE FROM sale_items WHERE saleId = :saleId")
-    fun deleteAllForSale(saleId: Long)
+    fun deleteAllForSale(saleId: String)
 }

--- a/app/src/main/java/com/medistock/data/dao/SiteDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/SiteDao.kt
@@ -19,5 +19,5 @@ interface SiteDao {
     fun getAll(): Flow<List<Site>>
 
     @Query("SELECT * FROM sites WHERE id = :siteId LIMIT 1")
-    fun getById(siteId: Long): Flow<Site?>
+    fun getById(siteId: String): Flow<Site?>
 }

--- a/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/StockMovementDao.kt
@@ -14,10 +14,10 @@ interface StockMovementDao {
     fun getAll(): Flow<List<StockMovement>>
 
     @Query("SELECT * FROM stock_movements WHERE productId = :productId AND siteId = :siteId ORDER BY date DESC")
-    fun getMovementsForProduct(productId: Long, siteId: Long): Flow<List<StockMovement>>
+    fun getMovementsForProduct(productId: String, siteId: String): Flow<List<StockMovement>>
 
     @Query("SELECT * FROM stock_movements WHERE siteId = :siteId")
-    fun getAllForSite(siteId: Long): Flow<List<StockMovement>>
+    fun getAllForSite(siteId: String): Flow<List<StockMovement>>
 
     /**
      * Calculate current stock for all products at a specific site.
@@ -46,7 +46,7 @@ interface StockMovementDao {
         GROUP BY p.id, s.id
         ORDER BY p.name
     """)
-    fun getCurrentStockForSite(siteId: Long): Flow<List<CurrentStock>>
+    fun getCurrentStockForSite(siteId: String): Flow<List<CurrentStock>>
 
     /**
      * Calculate current stock for all products across all sites.
@@ -84,7 +84,7 @@ interface StockMovementDao {
             p.name as productName,
             p.unit as unit,
             COALESCE(c.name, '') as categoryName,
-            0 as siteId,
+            'total' as siteId,
             'Total' as siteName,
             COALESCE(
                 SUM(CASE WHEN sm.type = 'in' THEN sm.quantity ELSE 0 END) -
@@ -99,7 +99,7 @@ interface StockMovementDao {
         WHERE p.id = :productId
         GROUP BY p.id
     """)
-    fun getTotalStockForProduct(productId: Long): Flow<CurrentStock?>
+    fun getTotalStockForProduct(productId: String): Flow<CurrentStock?>
 
     /**
      * Calculate current stock for a specific product across all sites.
@@ -127,7 +127,7 @@ interface StockMovementDao {
         GROUP BY p.id, s.id
         ORDER BY s.name
     """)
-    fun getCurrentStockForProduct(productId: Long): Flow<List<CurrentStock>>
+    fun getCurrentStockForProduct(productId: String): Flow<List<CurrentStock>>
 
     /**
      * Calculate current stock for a specific product at a specific site.
@@ -154,5 +154,5 @@ interface StockMovementDao {
         WHERE p.id = :productId AND s.id = :siteId
         GROUP BY p.id, s.id
     """)
-    fun getCurrentStockForProductAndSite(productId: Long, siteId: Long): Flow<List<CurrentStock>>
+    fun getCurrentStockForProductAndSite(productId: String, siteId: String): Flow<List<CurrentStock>>
 }

--- a/app/src/main/java/com/medistock/data/dao/UserDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/UserDao.kt
@@ -11,7 +11,7 @@ interface UserDao {
     fun getActiveUsers(): List<com.medistock.data.entities.User>
 
     @Query("SELECT * FROM app_users WHERE id = :userId")
-    fun getUserById(userId: Long): com.medistock.data.entities.User?
+    fun getUserById(userId: String): com.medistock.data.entities.User?
 
     @Query("SELECT * FROM app_users WHERE username = :username LIMIT 1")
     fun getUserByUsername(username: String): com.medistock.data.entities.User?
@@ -29,7 +29,7 @@ interface UserDao {
     fun deleteUser(user: com.medistock.data.entities.User)
 
     @Query("UPDATE app_users SET is_active = 0, updated_at = :timestamp, updated_by = :updatedBy WHERE id = :userId")
-    fun deactivateUser(userId: Long, timestamp: Long, updatedBy: String)
+    fun deactivateUser(userId: String, timestamp: Long, updatedBy: String)
 
     @Query("SELECT COUNT(*) FROM app_users WHERE is_admin = 1 AND is_active = 1")
     fun countActiveAdmins(): Int

--- a/app/src/main/java/com/medistock/data/dao/UserPermissionDao.kt
+++ b/app/src/main/java/com/medistock/data/dao/UserPermissionDao.kt
@@ -5,10 +5,10 @@ import androidx.room.*
 @Dao
 interface UserPermissionDao {
     @Query("SELECT * FROM user_permissions WHERE user_id = :userId")
-    fun getPermissionsForUser(userId: Long): List<com.medistock.data.entities.UserPermission>
+    fun getPermissionsForUser(userId: String): List<com.medistock.data.entities.UserPermission>
 
     @Query("SELECT * FROM user_permissions WHERE user_id = :userId AND module = :module LIMIT 1")
-    fun getPermissionForModule(userId: Long, module: String): com.medistock.data.entities.UserPermission?
+    fun getPermissionForModule(userId: String, module: String): com.medistock.data.entities.UserPermission?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertPermission(permission: com.medistock.data.entities.UserPermission): Long
@@ -23,8 +23,8 @@ interface UserPermissionDao {
     fun deletePermission(permission: com.medistock.data.entities.UserPermission)
 
     @Query("DELETE FROM user_permissions WHERE user_id = :userId")
-    fun deleteAllPermissionsForUser(userId: Long)
+    fun deleteAllPermissionsForUser(userId: String)
 
     @Query("DELETE FROM user_permissions WHERE user_id = :userId AND module = :module")
-    fun deletePermissionForModule(userId: Long, module: String)
+    fun deletePermissionForModule(userId: String, module: String)
 }

--- a/app/src/main/java/com/medistock/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/medistock/data/db/AppDatabase.kt
@@ -27,7 +27,7 @@ import com.medistock.data.entities.*
         AuditHistory::class,
         ProductTransfer::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/medistock/data/entities/AuditHistory.kt
+++ b/app/src/main/java/com/medistock/data/entities/AuditHistory.kt
@@ -3,17 +3,18 @@ package com.medistock.data.entities
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 /**
  * Audit history entity that tracks all data changes and entries in the system
  */
 @Entity(tableName = "audit_history")
 data class AuditHistory(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
 
     // Entity information
     @ColumnInfo(name = "entity_type") val entityType: String, // e.g., "Product", "Sale", "User"
-    @ColumnInfo(name = "entity_id") val entityId: Long, // ID of the affected entity
+    @ColumnInfo(name = "entity_id") val entityId: String, // ID of the affected entity
 
     // Action information
     @ColumnInfo(name = "action_type") val actionType: String, // "INSERT", "UPDATE", "DELETE"
@@ -28,6 +29,6 @@ data class AuditHistory(
     @ColumnInfo(name = "changed_at") val changedAt: Long = System.currentTimeMillis(),
 
     // Additional context
-    @ColumnInfo(name = "site_id") val siteId: Long? = null, // Site context if applicable
+    @ColumnInfo(name = "site_id") val siteId: String? = null, // Site context if applicable
     @ColumnInfo(name = "description") val description: String? = null // Optional description
 )

--- a/app/src/main/java/com/medistock/data/entities/Category.kt
+++ b/app/src/main/java/com/medistock/data/entities/Category.kt
@@ -2,10 +2,11 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(tableName = "categories")
 data class Category(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
     val name: String,
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis(),

--- a/app/src/main/java/com/medistock/data/entities/CurrentStock.kt
+++ b/app/src/main/java/com/medistock/data/entities/CurrentStock.kt
@@ -5,11 +5,11 @@ package com.medistock.data.entities
  * Calculated from stock movements (entries and exits).
  */
 data class CurrentStock(
-    val productId: Long,
+    val productId: String,
     val productName: String,
     val unit: String,
     val categoryName: String,
-    val siteId: Long,
+    val siteId: String,
     val siteName: String,
     val quantityOnHand: Double,
     val minStock: Double = 0.0,

--- a/app/src/main/java/com/medistock/data/entities/Customer.kt
+++ b/app/src/main/java/com/medistock/data/entities/Customer.kt
@@ -2,15 +2,16 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(tableName = "customers")
 data class Customer(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
     val name: String,
     val phone: String? = null,
     val address: String? = null,
     val notes: String? = null,
-    val siteId: Long,
+    val siteId: String,
     val createdAt: Long = System.currentTimeMillis(),
     val createdBy: String = ""
 )

--- a/app/src/main/java/com/medistock/data/entities/Inventory.kt
+++ b/app/src/main/java/com/medistock/data/entities/Inventory.kt
@@ -2,6 +2,7 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 /**
  * Represents a physical inventory count.
@@ -9,9 +10,9 @@ import androidx.room.PrimaryKey
  */
 @Entity(tableName = "inventories")
 data class Inventory(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    val productId: Long,
-    val siteId: Long,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    val productId: String,
+    val siteId: String,
     val countDate: Long,
     val countedQuantity: Double,
     val theoreticalQuantity: Double,

--- a/app/src/main/java/com/medistock/data/entities/PackagingType.kt
+++ b/app/src/main/java/com/medistock/data/entities/PackagingType.kt
@@ -2,6 +2,7 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 /**
  * PackagingType - Type de conditionnement administrable
@@ -13,8 +14,8 @@ import androidx.room.PrimaryKey
  */
 @Entity(tableName = "packaging_types")
 data class PackagingType(
-    @PrimaryKey(autoGenerate = true)
-    val id: Long = 0,
+    @PrimaryKey
+    val id: String = UUID.randomUUID().toString(),
 
     // Nom du type de conditionnement (ex: "Boîte/Comprimés", "Flacon/ml", "Units")
     val name: String,

--- a/app/src/main/java/com/medistock/data/entities/Product.kt
+++ b/app/src/main/java/com/medistock/data/entities/Product.kt
@@ -2,24 +2,25 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(tableName = "products")
 data class Product(
-    @PrimaryKey(autoGenerate = true)
-    val id: Long = 0,
+    @PrimaryKey
+    val id: String = UUID.randomUUID().toString(),
     val name: String,
     val unit: String, // Obligatoire - rempli automatiquement depuis PackagingType
     val unitVolume: Double, // Obligatoire - facteur de conversion
 
     // Nouveau système de conditionnement administrable
-    val packagingTypeId: Long? = null,  // FK vers packaging_types
+    val packagingTypeId: String? = null,  // FK vers packaging_types
     val selectedLevel: Int? = null,      // 1 ou 2 - niveau d'unité sélectionné
     val conversionFactor: Double? = null, // Facteur de conversion spécifique au produit (peut override celui du type)
 
-    val categoryId: Long?,  // Nullable to match queries
+    val categoryId: String?,  // Nullable to match queries
     val marginType: String?,  // Nullable
     val marginValue: Double?,  // Nullable
-    val siteId: Long,
+    val siteId: String,
     val minStock: Double? = 0.0,
     val maxStock: Double? = 0.0,
     val createdAt: Long = System.currentTimeMillis(),

--- a/app/src/main/java/com/medistock/data/entities/ProductPrice.kt
+++ b/app/src/main/java/com/medistock/data/entities/ProductPrice.kt
@@ -2,11 +2,12 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(tableName = "product_prices")
 data class ProductPrice(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    val productId: Long,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    val productId: String,
     val effectiveDate: Long,
     val purchasePrice: Double,
     val sellingPrice: Double,

--- a/app/src/main/java/com/medistock/data/entities/ProductSale.kt
+++ b/app/src/main/java/com/medistock/data/entities/ProductSale.kt
@@ -2,16 +2,17 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(tableName = "product_sales")
 data class ProductSale(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    val productId: Long,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    val productId: String,
     val quantity: Double,
     val priceAtSale: Double,
     val farmerName: String,
     val date: Long,
-    val siteId: Long,
+    val siteId: String,
     val createdAt: Long = System.currentTimeMillis(),
     val createdBy: String = ""
 )

--- a/app/src/main/java/com/medistock/data/entities/ProductTransfer.kt
+++ b/app/src/main/java/com/medistock/data/entities/ProductTransfer.kt
@@ -2,14 +2,15 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(tableName = "product_transfers")
 data class ProductTransfer(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    val productId: Long,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    val productId: String,
     val quantity: Double,
-    val fromSiteId: Long,
-    val toSiteId: Long,
+    val fromSiteId: String,
+    val toSiteId: String,
     val date: Long,
     val notes: String = "", // Optional notes about the transfer
     val createdAt: Long = System.currentTimeMillis(),

--- a/app/src/main/java/com/medistock/data/entities/ProductWithCategory.kt
+++ b/app/src/main/java/com/medistock/data/entities/ProductWithCategory.kt
@@ -1,15 +1,15 @@
 package com.medistock.data.entities
 
 data class ProductWithCategory(
-    val id: Long,
+    val id: String,
     val name: String,
     val unit: String,
-    val categoryId: Long?,
+    val categoryId: String?,
     val categoryName: String?,
     val marginType: String?,
     val marginValue: Double?,
     val unitVolume: Double?,
-    val siteId: Long,
+    val siteId: String,
     val minStock: Double?,
     val maxStock: Double?
 )

--- a/app/src/main/java/com/medistock/data/entities/PurchaseBatch.kt
+++ b/app/src/main/java/com/medistock/data/entities/PurchaseBatch.kt
@@ -2,6 +2,7 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 /**
  * Represents a purchase batch for FIFO (First In, First Out) inventory management.
@@ -9,9 +10,9 @@ import androidx.room.PrimaryKey
  */
 @Entity(tableName = "purchase_batches")
 data class PurchaseBatch(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    val productId: Long,
-    val siteId: Long,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    val productId: String,
+    val siteId: String,
     val batchNumber: String? = null, // Optional batch number (auto-generated if null)
     val purchaseDate: Long,
     val initialQuantity: Double,

--- a/app/src/main/java/com/medistock/data/entities/Sale.kt
+++ b/app/src/main/java/com/medistock/data/entities/Sale.kt
@@ -2,15 +2,16 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(tableName = "sales")
 data class Sale(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
     val customerName: String,
-    val customerId: Long? = null,
+    val customerId: String? = null,
     val date: Long,
     val totalAmount: Double,
-    val siteId: Long,
+    val siteId: String,
     val createdAt: Long = System.currentTimeMillis(),
     val createdBy: String = ""
 )

--- a/app/src/main/java/com/medistock/data/entities/SaleBatchAllocation.kt
+++ b/app/src/main/java/com/medistock/data/entities/SaleBatchAllocation.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 /**
  * Tracks which purchase batches were used for each sale item.
@@ -28,9 +29,9 @@ import androidx.room.PrimaryKey
     indices = [Index("saleItemId"), Index("batchId")]
 )
 data class SaleBatchAllocation(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    val saleItemId: Long,
-    val batchId: Long,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    val saleItemId: String,
+    val batchId: String,
     val quantityAllocated: Double, // Quantity taken from this batch
     val purchasePriceAtAllocation: Double, // Purchase price of the batch at time of sale
     val createdAt: Long = System.currentTimeMillis()

--- a/app/src/main/java/com/medistock/data/entities/SaleItem.kt
+++ b/app/src/main/java/com/medistock/data/entities/SaleItem.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(
     tableName = "sale_items",
@@ -24,9 +25,9 @@ import androidx.room.PrimaryKey
     indices = [Index("saleId"), Index("productId")]
 )
 data class SaleItem(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    val saleId: Long,
-    val productId: Long,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    val saleId: String,
+    val productId: String,
     val productName: String,
     val unit: String,
     val quantity: Double,

--- a/app/src/main/java/com/medistock/data/entities/Site.kt
+++ b/app/src/main/java/com/medistock/data/entities/Site.kt
@@ -2,10 +2,11 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(tableName = "sites")
 data class Site(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
     val name: String,
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis(),

--- a/app/src/main/java/com/medistock/data/entities/StockMovement.kt
+++ b/app/src/main/java/com/medistock/data/entities/StockMovement.kt
@@ -2,17 +2,18 @@ package com.medistock.data.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(tableName = "stock_movements")
 data class StockMovement(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    val productId: Long,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    val productId: String,
     val type: String,
     val quantity: Double,
     val date: Long,
     val purchasePriceAtMovement: Double,
     val sellingPriceAtMovement: Double,
-    val siteId: Long,
+    val siteId: String,
     val createdAt: Long = System.currentTimeMillis(),
     val createdBy: String = ""
 )

--- a/app/src/main/java/com/medistock/data/entities/User.kt
+++ b/app/src/main/java/com/medistock/data/entities/User.kt
@@ -3,10 +3,11 @@ package com.medistock.data.entities
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(tableName = "app_users")
 data class User(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
     val username: String,
     val password: String, // BCrypt hashed password
     @ColumnInfo(name = "full_name") val fullName: String,

--- a/app/src/main/java/com/medistock/data/entities/UserPermission.kt
+++ b/app/src/main/java/com/medistock/data/entities/UserPermission.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 @Entity(
     tableName = "user_permissions",
@@ -19,8 +20,8 @@ import androidx.room.PrimaryKey
     indices = [Index("user_id")]
 )
 data class UserPermission(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    @ColumnInfo(name = "user_id") val userId: Long,
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    @ColumnInfo(name = "user_id") val userId: String,
     val module: String,
     @ColumnInfo(name = "can_view") val canView: Boolean = false,
     @ColumnInfo(name = "can_create") val canCreate: Boolean = false,

--- a/app/src/main/java/com/medistock/data/remote/dto/AuditDtos.kt
+++ b/app/src/main/java/com/medistock/data/remote/dto/AuditDtos.kt
@@ -2,22 +2,23 @@ package com.medistock.data.remote.dto
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.UUID
 
 /**
  * DTO pour la table audit_history
  */
 @Serializable
 data class AuditHistoryDto(
-    val id: Long = 0,
+    val id: String = UUID.randomUUID().toString(),
     @SerialName("entity_type") val entityType: String,
-    @SerialName("entity_id") val entityId: Long,
+    @SerialName("entity_id") val entityId: String,
     @SerialName("action_type") val actionType: String, // "INSERT", "UPDATE", "DELETE"
     @SerialName("field_name") val fieldName: String? = null,
     @SerialName("old_value") val oldValue: String? = null,
     @SerialName("new_value") val newValue: String? = null,
     @SerialName("changed_by") val changedBy: String,
     @SerialName("changed_at") val changedAt: Long = System.currentTimeMillis(),
-    @SerialName("site_id") val siteId: Long? = null,
+    @SerialName("site_id") val siteId: String? = null,
     val description: String? = null
 )
 
@@ -26,9 +27,9 @@ data class AuditHistoryDto(
  */
 @Serializable
 data class CurrentStockDto(
-    @SerialName("product_id") val productId: Long,
+    @SerialName("product_id") val productId: String,
     @SerialName("product_name") val productName: String,
-    @SerialName("site_id") val siteId: Long,
+    @SerialName("site_id") val siteId: String,
     @SerialName("site_name") val siteName: String,
     @SerialName("current_stock") val currentStock: Double,
     @SerialName("min_stock") val minStock: Double?,

--- a/app/src/main/java/com/medistock/data/remote/dto/BasicDtos.kt
+++ b/app/src/main/java/com/medistock/data/remote/dto/BasicDtos.kt
@@ -2,13 +2,14 @@ package com.medistock.data.remote.dto
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.UUID
 
 /**
  * DTO pour la table sites
  */
 @Serializable
 data class SiteDto(
-    val id: Long = 0,
+    val id: String = UUID.randomUUID().toString(),
     val name: String,
     @SerialName("created_at") val createdAt: Long = System.currentTimeMillis(),
     @SerialName("updated_at") val updatedAt: Long = System.currentTimeMillis(),
@@ -21,7 +22,7 @@ data class SiteDto(
  */
 @Serializable
 data class CategoryDto(
-    val id: Long = 0,
+    val id: String = UUID.randomUUID().toString(),
     val name: String,
     @SerialName("created_at") val createdAt: Long = System.currentTimeMillis(),
     @SerialName("updated_at") val updatedAt: Long = System.currentTimeMillis(),
@@ -34,7 +35,7 @@ data class CategoryDto(
  */
 @Serializable
 data class PackagingTypeDto(
-    val id: Long = 0,
+    val id: String = UUID.randomUUID().toString(),
     val name: String,
     @SerialName("level1_name") val level1Name: String,
     @SerialName("level2_name") val level2Name: String? = null,
@@ -52,7 +53,7 @@ data class PackagingTypeDto(
  */
 @Serializable
 data class AppUserDto(
-    val id: Long = 0,
+    val id: String = UUID.randomUUID().toString(),
     val username: String,
     val password: String,
     @SerialName("full_name") val fullName: String,
@@ -69,8 +70,8 @@ data class AppUserDto(
  */
 @Serializable
 data class UserPermissionDto(
-    val id: Long = 0,
-    @SerialName("user_id") val userId: Long,
+    val id: String = UUID.randomUUID().toString(),
+    @SerialName("user_id") val userId: String,
     val module: String,
     @SerialName("can_view") val canView: Boolean = false,
     @SerialName("can_create") val canCreate: Boolean = false,
@@ -87,12 +88,12 @@ data class UserPermissionDto(
  */
 @Serializable
 data class CustomerDto(
-    val id: Long = 0,
+    val id: String = UUID.randomUUID().toString(),
     val name: String,
     val phone: String? = null,
     val address: String? = null,
     val notes: String? = null,
-    @SerialName("site_id") val siteId: Long,
+    @SerialName("site_id") val siteId: String,
     @SerialName("created_at") val createdAt: Long = System.currentTimeMillis(),
     @SerialName("created_by") val createdBy: String = ""
 )

--- a/app/src/main/java/com/medistock/data/remote/dto/ProductDtos.kt
+++ b/app/src/main/java/com/medistock/data/remote/dto/ProductDtos.kt
@@ -2,23 +2,24 @@ package com.medistock.data.remote.dto
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.UUID
 
 /**
  * DTO pour la table products
  */
 @Serializable
 data class ProductDto(
-    val id: Long = 0,
+    val id: String = UUID.randomUUID().toString(),
     val name: String,
     val unit: String,
     @SerialName("unit_volume") val unitVolume: Double,
-    @SerialName("packaging_type_id") val packagingTypeId: Long? = null,
+    @SerialName("packaging_type_id") val packagingTypeId: String? = null,
     @SerialName("selected_level") val selectedLevel: Int? = null,
     @SerialName("conversion_factor") val conversionFactor: Double? = null,
-    @SerialName("category_id") val categoryId: Long? = null,
+    @SerialName("category_id") val categoryId: String? = null,
     @SerialName("margin_type") val marginType: String? = null,
     @SerialName("margin_value") val marginValue: Double? = null,
-    @SerialName("site_id") val siteId: Long,
+    @SerialName("site_id") val siteId: String,
     @SerialName("min_stock") val minStock: Double? = 0.0,
     @SerialName("max_stock") val maxStock: Double? = 0.0,
     @SerialName("created_at") val createdAt: Long = System.currentTimeMillis(),
@@ -32,8 +33,8 @@ data class ProductDto(
  */
 @Serializable
 data class ProductPriceDto(
-    val id: Long = 0,
-    @SerialName("product_id") val productId: Long,
+    val id: String = UUID.randomUUID().toString(),
+    @SerialName("product_id") val productId: String,
     @SerialName("effective_date") val effectiveDate: Long,
     @SerialName("purchase_price") val purchasePrice: Double,
     @SerialName("selling_price") val sellingPrice: Double,

--- a/app/src/main/java/com/medistock/data/remote/dto/SalesDtos.kt
+++ b/app/src/main/java/com/medistock/data/remote/dto/SalesDtos.kt
@@ -2,18 +2,19 @@ package com.medistock.data.remote.dto
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.UUID
 
 /**
  * DTO pour la table sales
  */
 @Serializable
 data class SaleDto(
-    val id: Long = 0,
+    val id: String = UUID.randomUUID().toString(),
     @SerialName("customer_name") val customerName: String,
-    @SerialName("customer_id") val customerId: Long? = null,
+    @SerialName("customer_id") val customerId: String? = null,
     val date: Long,
     @SerialName("total_amount") val totalAmount: Double,
-    @SerialName("site_id") val siteId: Long,
+    @SerialName("site_id") val siteId: String,
     @SerialName("created_at") val createdAt: Long = System.currentTimeMillis(),
     @SerialName("created_by") val createdBy: String = ""
 )
@@ -23,9 +24,9 @@ data class SaleDto(
  */
 @Serializable
 data class SaleItemDto(
-    val id: Long = 0,
-    @SerialName("sale_id") val saleId: Long,
-    @SerialName("product_id") val productId: Long,
+    val id: String = UUID.randomUUID().toString(),
+    @SerialName("sale_id") val saleId: String,
+    @SerialName("product_id") val productId: String,
     @SerialName("product_name") val productName: String,
     val unit: String,
     val quantity: Double,
@@ -38,9 +39,9 @@ data class SaleItemDto(
  */
 @Serializable
 data class SaleBatchAllocationDto(
-    val id: Long = 0,
-    @SerialName("sale_item_id") val saleItemId: Long,
-    @SerialName("batch_id") val batchId: Long,
+    val id: String = UUID.randomUUID().toString(),
+    @SerialName("sale_item_id") val saleItemId: String,
+    @SerialName("batch_id") val batchId: String,
     @SerialName("quantity_allocated") val quantityAllocated: Double,
     @SerialName("purchase_price_at_allocation") val purchasePriceAtAllocation: Double,
     @SerialName("created_at") val createdAt: Long = System.currentTimeMillis()
@@ -51,13 +52,13 @@ data class SaleBatchAllocationDto(
  */
 @Serializable
 data class ProductSaleDto(
-    val id: Long = 0,
-    @SerialName("product_id") val productId: Long,
+    val id: String = UUID.randomUUID().toString(),
+    @SerialName("product_id") val productId: String,
     val quantity: Double,
     @SerialName("price_at_sale") val priceAtSale: Double,
     @SerialName("farmer_name") val farmerName: String,
     val date: Long,
-    @SerialName("site_id") val siteId: Long,
+    @SerialName("site_id") val siteId: String,
     @SerialName("created_at") val createdAt: Long = System.currentTimeMillis(),
     @SerialName("created_by") val createdBy: String = ""
 )

--- a/app/src/main/java/com/medistock/data/remote/dto/StockDtos.kt
+++ b/app/src/main/java/com/medistock/data/remote/dto/StockDtos.kt
@@ -2,15 +2,16 @@ package com.medistock.data.remote.dto
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.UUID
 
 /**
  * DTO pour la table purchase_batches
  */
 @Serializable
 data class PurchaseBatchDto(
-    val id: Long = 0,
-    @SerialName("product_id") val productId: Long,
-    @SerialName("site_id") val siteId: Long,
+    val id: String = UUID.randomUUID().toString(),
+    @SerialName("product_id") val productId: String,
+    @SerialName("site_id") val siteId: String,
     @SerialName("batch_number") val batchNumber: String? = null,
     @SerialName("purchase_date") val purchaseDate: Long,
     @SerialName("initial_quantity") val initialQuantity: Double,
@@ -30,14 +31,14 @@ data class PurchaseBatchDto(
  */
 @Serializable
 data class StockMovementDto(
-    val id: Long = 0,
-    @SerialName("product_id") val productId: Long,
+    val id: String = UUID.randomUUID().toString(),
+    @SerialName("product_id") val productId: String,
     val type: String, // "IN" or "OUT"
     val quantity: Double,
     val date: Long,
     @SerialName("purchase_price_at_movement") val purchasePriceAtMovement: Double,
     @SerialName("selling_price_at_movement") val sellingPriceAtMovement: Double,
-    @SerialName("site_id") val siteId: Long,
+    @SerialName("site_id") val siteId: String,
     @SerialName("created_at") val createdAt: Long = System.currentTimeMillis(),
     @SerialName("created_by") val createdBy: String = ""
 )
@@ -47,9 +48,9 @@ data class StockMovementDto(
  */
 @Serializable
 data class InventoryDto(
-    val id: Long = 0,
-    @SerialName("product_id") val productId: Long,
-    @SerialName("site_id") val siteId: Long,
+    val id: String = UUID.randomUUID().toString(),
+    @SerialName("product_id") val productId: String,
+    @SerialName("site_id") val siteId: String,
     @SerialName("count_date") val countDate: Long,
     @SerialName("counted_quantity") val countedQuantity: Double,
     @SerialName("theoretical_quantity") val theoreticalQuantity: Double,
@@ -66,11 +67,11 @@ data class InventoryDto(
  */
 @Serializable
 data class ProductTransferDto(
-    val id: Long = 0,
-    @SerialName("product_id") val productId: Long,
+    val id: String = UUID.randomUUID().toString(),
+    @SerialName("product_id") val productId: String,
     val quantity: Double,
-    @SerialName("from_site_id") val fromSiteId: Long,
-    @SerialName("to_site_id") val toSiteId: Long,
+    @SerialName("from_site_id") val fromSiteId: String,
+    @SerialName("to_site_id") val toSiteId: String,
     val date: Long,
     val notes: String = "",
     @SerialName("created_at") val createdAt: Long = System.currentTimeMillis(),

--- a/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/AuditRepository.kt
@@ -11,14 +11,14 @@ class AuditHistorySupabaseRepository : BaseSupabaseRepository("audit_history") {
 
     suspend fun getAllAuditHistory(): List<AuditHistoryDto> = getAll()
 
-    suspend fun getAuditHistoryById(id: Long): AuditHistoryDto? = getById(id)
+    suspend fun getAuditHistoryById(id: String): AuditHistoryDto? = getById(id)
 
     suspend fun createAuditEntry(audit: AuditHistoryDto): AuditHistoryDto = create(audit)
 
     /**
      * Récupère l'historique d'une entité spécifique
      */
-    suspend fun getAuditHistoryByEntity(entityType: String, entityId: Long): List<AuditHistoryDto> {
+    suspend fun getAuditHistoryByEntity(entityType: String, entityId: String): List<AuditHistoryDto> {
         return supabase.from(tableName).select {
             filter {
                 eq("entity_type", entityType)
@@ -43,7 +43,7 @@ class AuditHistorySupabaseRepository : BaseSupabaseRepository("audit_history") {
     /**
      * Récupère l'historique d'un site
      */
-    suspend fun getAuditHistoryBySite(siteId: Long): List<AuditHistoryDto> {
+    suspend fun getAuditHistoryBySite(siteId: String): List<AuditHistoryDto> {
         return supabase.from(tableName).select {
             filter {
                 eq("site_id", siteId)
@@ -89,7 +89,7 @@ class AuditHistorySupabaseRepository : BaseSupabaseRepository("audit_history") {
      */
     suspend fun getAuditHistoryByField(
         entityType: String,
-        entityId: Long,
+        entityId: String,
         fieldName: String
     ): List<AuditHistoryDto> {
         return supabase.from(tableName).select {

--- a/app/src/main/java/com/medistock/data/remote/repository/BaseSupabaseRepository.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BaseSupabaseRepository.kt
@@ -23,7 +23,7 @@ abstract class BaseSupabaseRepository(
     /**
      * Récupère un enregistrement par ID
      */
-    suspend inline fun <reified R> getById(id: Long): R? {
+    suspend inline fun <reified R> getById(id: String): R? {
         return try {
             supabase.from(tableName)
                 .select {
@@ -49,7 +49,7 @@ abstract class BaseSupabaseRepository(
     /**
      * Met à jour un enregistrement
      */
-    suspend inline fun <reified R : Any> update(id: Long, item: R): R {
+    suspend inline fun <reified R : Any> update(id: String, item: R): R {
         return supabase.from(tableName).update(item) {
             select()
             filter {
@@ -71,7 +71,7 @@ abstract class BaseSupabaseRepository(
     /**
      * Supprime un enregistrement
      */
-    suspend fun delete(id: Long) {
+    suspend fun delete(id: String) {
         supabase.from(tableName).delete {
             filter {
                 eq("id", id)

--- a/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/BasicRepositories.kt
@@ -6,11 +6,11 @@ import io.github.jan.supabase.postgrest.query.Order
 
 class SiteSupabaseRepository : BaseSupabaseRepository("sites") {
     suspend fun getAllSites(): List<SiteDto> = getAll()
-    suspend fun getSiteById(id: Long): SiteDto? = getById(id)
+    suspend fun getSiteById(id: String): SiteDto? = getById(id)
     suspend fun createSite(site: SiteDto): SiteDto = create(site)
-    suspend fun updateSite(id: Long, site: SiteDto): SiteDto = update(id, site)
+    suspend fun updateSite(id: String, site: SiteDto): SiteDto = update(id, site)
     suspend fun upsertSite(site: SiteDto): SiteDto = upsert(site)
-    suspend fun deleteSite(id: Long) = delete(id)
+    suspend fun deleteSite(id: String) = delete(id)
 
     suspend fun searchByName(name: String): List<SiteDto> {
         return supabase.from(tableName).select {
@@ -21,11 +21,11 @@ class SiteSupabaseRepository : BaseSupabaseRepository("sites") {
 
 class CategorySupabaseRepository : BaseSupabaseRepository("categories") {
     suspend fun getAllCategories(): List<CategoryDto> = getAll()
-    suspend fun getCategoryById(id: Long): CategoryDto? = getById(id)
+    suspend fun getCategoryById(id: String): CategoryDto? = getById(id)
     suspend fun createCategory(category: CategoryDto): CategoryDto = create(category)
-    suspend fun updateCategory(id: Long, category: CategoryDto): CategoryDto = update(id, category)
+    suspend fun updateCategory(id: String, category: CategoryDto): CategoryDto = update(id, category)
     suspend fun upsertCategory(category: CategoryDto): CategoryDto = upsert(category)
-    suspend fun deleteCategory(id: Long) = delete(id)
+    suspend fun deleteCategory(id: String) = delete(id)
 
     suspend fun searchByName(name: String): List<CategoryDto> {
         return supabase.from(tableName).select {
@@ -36,11 +36,11 @@ class CategorySupabaseRepository : BaseSupabaseRepository("categories") {
 
 class PackagingTypeSupabaseRepository : BaseSupabaseRepository("packaging_types") {
     suspend fun getAllPackagingTypes(): List<PackagingTypeDto> = getAll()
-    suspend fun getPackagingTypeById(id: Long): PackagingTypeDto? = getById(id)
+    suspend fun getPackagingTypeById(id: String): PackagingTypeDto? = getById(id)
     suspend fun createPackagingType(packagingType: PackagingTypeDto): PackagingTypeDto = create(packagingType)
-    suspend fun updatePackagingType(id: Long, packagingType: PackagingTypeDto): PackagingTypeDto = update(id, packagingType)
+    suspend fun updatePackagingType(id: String, packagingType: PackagingTypeDto): PackagingTypeDto = update(id, packagingType)
     suspend fun upsertPackagingType(packagingType: PackagingTypeDto): PackagingTypeDto = upsert(packagingType)
-    suspend fun deletePackagingType(id: Long) = delete(id)
+    suspend fun deletePackagingType(id: String) = delete(id)
 
     suspend fun getActivePackagingTypes(): List<PackagingTypeDto> {
         return supabase.from(tableName).select {
@@ -57,13 +57,13 @@ class PackagingTypeSupabaseRepository : BaseSupabaseRepository("packaging_types"
 
 class CustomerSupabaseRepository : BaseSupabaseRepository("customers") {
     suspend fun getAllCustomers(): List<CustomerDto> = getAll()
-    suspend fun getCustomerById(id: Long): CustomerDto? = getById(id)
+    suspend fun getCustomerById(id: String): CustomerDto? = getById(id)
     suspend fun createCustomer(customer: CustomerDto): CustomerDto = create(customer)
-    suspend fun updateCustomer(id: Long, customer: CustomerDto): CustomerDto = update(id, customer)
+    suspend fun updateCustomer(id: String, customer: CustomerDto): CustomerDto = update(id, customer)
     suspend fun upsertCustomer(customer: CustomerDto): CustomerDto = upsert(customer)
-    suspend fun deleteCustomer(id: Long) = delete(id)
+    suspend fun deleteCustomer(id: String) = delete(id)
 
-    suspend fun getCustomersBySite(siteId: Long): List<CustomerDto> {
+    suspend fun getCustomersBySite(siteId: String): List<CustomerDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
         }.decodeList()

--- a/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/ProductRepositories.kt
@@ -8,25 +8,25 @@ import io.github.jan.supabase.postgrest.query.Order
 
 class ProductSupabaseRepository : BaseSupabaseRepository("products") {
     suspend fun getAllProducts(): List<ProductDto> = getAll()
-    suspend fun getProductById(id: Long): ProductDto? = getById(id)
+    suspend fun getProductById(id: String): ProductDto? = getById(id)
     suspend fun createProduct(product: ProductDto): ProductDto = create(product)
-    suspend fun updateProduct(id: Long, product: ProductDto): ProductDto = update(id, product)
+    suspend fun updateProduct(id: String, product: ProductDto): ProductDto = update(id, product)
     suspend fun upsertProduct(product: ProductDto): ProductDto = upsert(product)
-    suspend fun deleteProduct(id: Long) = delete(id)
+    suspend fun deleteProduct(id: String) = delete(id)
 
-    suspend fun getProductsBySite(siteId: Long): List<ProductDto> {
+    suspend fun getProductsBySite(siteId: String): List<ProductDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
         }.decodeList()
     }
 
-    suspend fun getProductsByCategory(categoryId: Long): List<ProductDto> {
+    suspend fun getProductsByCategory(categoryId: String): List<ProductDto> {
         return supabase.from(tableName).select {
             filter { eq("category_id", categoryId) }
         }.decodeList()
     }
 
-    suspend fun getProductsByPackagingType(packagingTypeId: Long): List<ProductDto> {
+    suspend fun getProductsByPackagingType(packagingTypeId: String): List<ProductDto> {
         return supabase.from(tableName).select {
             filter { eq("packaging_type_id", packagingTypeId) }
         }.decodeList()
@@ -41,19 +41,19 @@ class ProductSupabaseRepository : BaseSupabaseRepository("products") {
 
 class ProductPriceSupabaseRepository : BaseSupabaseRepository("product_prices") {
     suspend fun getAllPrices(): List<ProductPriceDto> = getAll()
-    suspend fun getPriceById(id: Long): ProductPriceDto? = getById(id)
+    suspend fun getPriceById(id: String): ProductPriceDto? = getById(id)
     suspend fun createPrice(price: ProductPriceDto): ProductPriceDto = create(price)
-    suspend fun updatePrice(id: Long, price: ProductPriceDto): ProductPriceDto = update(id, price)
-    suspend fun deletePrice(id: Long) = delete(id)
+    suspend fun updatePrice(id: String, price: ProductPriceDto): ProductPriceDto = update(id, price)
+    suspend fun deletePrice(id: String) = delete(id)
 
-    suspend fun getPriceHistoryByProduct(productId: Long): List<ProductPriceDto> {
+    suspend fun getPriceHistoryByProduct(productId: String): List<ProductPriceDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
             order(column = "effective_date", order = Order.DESCENDING)
         }.decodeList()
     }
 
-    suspend fun getCurrentPrice(productId: Long): ProductPriceDto? {
+    suspend fun getCurrentPrice(productId: String): ProductPriceDto? {
         val now = System.currentTimeMillis()
         return supabase.from(tableName).select {
             filter {
@@ -75,19 +75,19 @@ class ProductPriceSupabaseRepository : BaseSupabaseRepository("product_prices") 
 class CurrentStockRepository : BaseSupabaseRepository("current_stock") {
     suspend fun getAllStock(): List<CurrentStockDto> = getAll()
 
-    suspend fun getStockByProduct(productId: Long): CurrentStockDto? {
+    suspend fun getStockByProduct(productId: String): CurrentStockDto? {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
         }.decodeList<CurrentStockDto>().firstOrNull()
     }
 
-    suspend fun getStockBySite(siteId: Long): List<CurrentStockDto> {
+    suspend fun getStockBySite(siteId: String): List<CurrentStockDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
         }.decodeList()
     }
 
-    suspend fun getLowStockProducts(siteId: Long? = null): List<CurrentStockDto> {
+    suspend fun getLowStockProducts(siteId: String? = null): List<CurrentStockDto> {
         return supabase.from(tableName).select {
             filter {
                 eq("stock_status", "LOW")
@@ -98,7 +98,7 @@ class CurrentStockRepository : BaseSupabaseRepository("current_stock") {
         }.decodeList()
     }
 
-    suspend fun getHighStockProducts(siteId: Long? = null): List<CurrentStockDto> {
+    suspend fun getHighStockProducts(siteId: String? = null): List<CurrentStockDto> {
         return supabase.from(tableName).select {
             filter {
                 eq("stock_status", "HIGH")

--- a/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/SalesRepositories.kt
@@ -6,19 +6,19 @@ import io.github.jan.supabase.postgrest.query.Order
 
 class SaleSupabaseRepository : BaseSupabaseRepository("sales") {
     suspend fun getAllSales(): List<SaleDto> = getAll()
-    suspend fun getSaleById(id: Long): SaleDto? = getById(id)
+    suspend fun getSaleById(id: String): SaleDto? = getById(id)
     suspend fun createSale(sale: SaleDto): SaleDto = create(sale)
-    suspend fun updateSale(id: Long, sale: SaleDto): SaleDto = update(id, sale)
-    suspend fun deleteSale(id: Long) = delete(id)
+    suspend fun updateSale(id: String, sale: SaleDto): SaleDto = update(id, sale)
+    suspend fun deleteSale(id: String) = delete(id)
 
-    suspend fun getSalesBySite(siteId: Long): List<SaleDto> {
+    suspend fun getSalesBySite(siteId: String): List<SaleDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
             order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
-    suspend fun getSalesByCustomer(customerId: Long): List<SaleDto> {
+    suspend fun getSalesByCustomer(customerId: String): List<SaleDto> {
         return supabase.from(tableName).select {
             filter { eq("customer_id", customerId) }
             order(column = "date", order = Order.DESCENDING)
@@ -28,7 +28,7 @@ class SaleSupabaseRepository : BaseSupabaseRepository("sales") {
     suspend fun getSalesByDateRange(
         startDate: Long,
         endDate: Long,
-        siteId: Long? = null
+        siteId: String? = null
     ): List<SaleDto> {
         return supabase.from(tableName).select {
             filter {
@@ -49,7 +49,7 @@ class SaleSupabaseRepository : BaseSupabaseRepository("sales") {
         }.decodeList()
     }
 
-    suspend fun getTodaySales(siteId: Long? = null): List<SaleDto> {
+    suspend fun getTodaySales(siteId: String? = null): List<SaleDto> {
         val today = System.currentTimeMillis()
         val startOfDay = today - (today % (24 * 60 * 60 * 1000))
         return getSalesByDateRange(startOfDay, today, siteId)
@@ -58,24 +58,24 @@ class SaleSupabaseRepository : BaseSupabaseRepository("sales") {
 
 class SaleItemSupabaseRepository : BaseSupabaseRepository("sale_items") {
     suspend fun getAllSaleItems(): List<SaleItemDto> = getAll()
-    suspend fun getSaleItemById(id: Long): SaleItemDto? = getById(id)
+    suspend fun getSaleItemById(id: String): SaleItemDto? = getById(id)
     suspend fun createSaleItem(saleItem: SaleItemDto): SaleItemDto = create(saleItem)
-    suspend fun updateSaleItem(id: Long, saleItem: SaleItemDto): SaleItemDto = update(id, saleItem)
-    suspend fun deleteSaleItem(id: Long) = delete(id)
+    suspend fun updateSaleItem(id: String, saleItem: SaleItemDto): SaleItemDto = update(id, saleItem)
+    suspend fun deleteSaleItem(id: String) = delete(id)
 
-    suspend fun getSaleItemsBySale(saleId: Long): List<SaleItemDto> {
+    suspend fun getSaleItemsBySale(saleId: String): List<SaleItemDto> {
         return supabase.from(tableName).select {
             filter { eq("sale_id", saleId) }
         }.decodeList()
     }
 
-    suspend fun getSaleItemsByProduct(productId: Long): List<SaleItemDto> {
+    suspend fun getSaleItemsByProduct(productId: String): List<SaleItemDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
         }.decodeList()
     }
 
-    suspend fun deleteAllSaleItems(saleId: Long) {
+    suspend fun deleteAllSaleItems(saleId: String) {
         supabase.from(tableName).delete {
             filter { eq("sale_id", saleId) }
         }
@@ -84,23 +84,23 @@ class SaleItemSupabaseRepository : BaseSupabaseRepository("sale_items") {
 
 class SaleBatchAllocationSupabaseRepository : BaseSupabaseRepository("sale_batch_allocations") {
     suspend fun getAllAllocations(): List<SaleBatchAllocationDto> = getAll()
-    suspend fun getAllocationById(id: Long): SaleBatchAllocationDto? = getById(id)
+    suspend fun getAllocationById(id: String): SaleBatchAllocationDto? = getById(id)
     suspend fun createAllocation(allocation: SaleBatchAllocationDto): SaleBatchAllocationDto = create(allocation)
 
-    suspend fun getAllocationsBySaleItem(saleItemId: Long): List<SaleBatchAllocationDto> {
+    suspend fun getAllocationsBySaleItem(saleItemId: String): List<SaleBatchAllocationDto> {
         return supabase.from(tableName).select {
             filter { eq("sale_item_id", saleItemId) }
         }.decodeList()
     }
 
-    suspend fun getAllocationsByBatch(batchId: Long): List<SaleBatchAllocationDto> {
+    suspend fun getAllocationsByBatch(batchId: String): List<SaleBatchAllocationDto> {
         return supabase.from(tableName).select {
             filter { eq("batch_id", batchId) }
             order(column = "created_at", order = Order.DESCENDING)
         }.decodeList()
     }
 
-    suspend fun deleteAllocationsBySaleItem(saleItemId: Long) {
+    suspend fun deleteAllocationsBySaleItem(saleItemId: String) {
         supabase.from(tableName).delete {
             filter { eq("sale_item_id", saleItemId) }
         }
@@ -109,17 +109,17 @@ class SaleBatchAllocationSupabaseRepository : BaseSupabaseRepository("sale_batch
 
 class ProductSaleSupabaseRepository : BaseSupabaseRepository("product_sales") {
     suspend fun getAllProductSales(): List<ProductSaleDto> = getAll()
-    suspend fun getProductSaleById(id: Long): ProductSaleDto? = getById(id)
+    suspend fun getProductSaleById(id: String): ProductSaleDto? = getById(id)
     suspend fun createProductSale(productSale: ProductSaleDto): ProductSaleDto = create(productSale)
 
-    suspend fun getProductSalesByProduct(productId: Long): List<ProductSaleDto> {
+    suspend fun getProductSalesByProduct(productId: String): List<ProductSaleDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
             order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
-    suspend fun getProductSalesBySite(siteId: Long): List<ProductSaleDto> {
+    suspend fun getProductSalesBySite(siteId: String): List<ProductSaleDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
             order(column = "date", order = Order.DESCENDING)

--- a/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/StockRepositories.kt
@@ -6,19 +6,19 @@ import io.github.jan.supabase.postgrest.query.Order
 
 class PurchaseBatchSupabaseRepository : BaseSupabaseRepository("purchase_batches") {
     suspend fun getAllBatches(): List<PurchaseBatchDto> = getAll()
-    suspend fun getBatchById(id: Long): PurchaseBatchDto? = getById(id)
+    suspend fun getBatchById(id: String): PurchaseBatchDto? = getById(id)
     suspend fun createBatch(batch: PurchaseBatchDto): PurchaseBatchDto = create(batch)
-    suspend fun updateBatch(id: Long, batch: PurchaseBatchDto): PurchaseBatchDto = update(id, batch)
-    suspend fun deleteBatch(id: Long) = delete(id)
+    suspend fun updateBatch(id: String, batch: PurchaseBatchDto): PurchaseBatchDto = update(id, batch)
+    suspend fun deleteBatch(id: String) = delete(id)
 
-    suspend fun getBatchesByProduct(productId: Long): List<PurchaseBatchDto> {
+    suspend fun getBatchesByProduct(productId: String): List<PurchaseBatchDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
             order(column = "purchase_date", order = Order.ASCENDING)
         }.decodeList()
     }
 
-    suspend fun getActiveBatchesByProduct(productId: Long): List<PurchaseBatchDto> {
+    suspend fun getActiveBatchesByProduct(productId: String): List<PurchaseBatchDto> {
         return supabase.from(tableName).select {
             filter {
                 eq("product_id", productId)
@@ -28,7 +28,7 @@ class PurchaseBatchSupabaseRepository : BaseSupabaseRepository("purchase_batches
         }.decodeList()
     }
 
-    suspend fun getBatchesBySite(siteId: Long): List<PurchaseBatchDto> {
+    suspend fun getBatchesBySite(siteId: String): List<PurchaseBatchDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
         }.decodeList()
@@ -54,24 +54,24 @@ class PurchaseBatchSupabaseRepository : BaseSupabaseRepository("purchase_batches
 
 class StockMovementSupabaseRepository : BaseSupabaseRepository("stock_movements") {
     suspend fun getAllMovements(): List<StockMovementDto> = getAll()
-    suspend fun getMovementById(id: Long): StockMovementDto? = getById(id)
+    suspend fun getMovementById(id: String): StockMovementDto? = getById(id)
     suspend fun createMovement(movement: StockMovementDto): StockMovementDto = create(movement)
 
-    suspend fun getMovementsByProduct(productId: Long): List<StockMovementDto> {
+    suspend fun getMovementsByProduct(productId: String): List<StockMovementDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
             order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
-    suspend fun getMovementsBySite(siteId: Long): List<StockMovementDto> {
+    suspend fun getMovementsBySite(siteId: String): List<StockMovementDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
             order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
-    suspend fun getMovementsByType(type: String, siteId: Long? = null): List<StockMovementDto> {
+    suspend fun getMovementsByType(type: String, siteId: String? = null): List<StockMovementDto> {
         return supabase.from(tableName).select {
             filter {
                 eq("type", type)
@@ -86,7 +86,7 @@ class StockMovementSupabaseRepository : BaseSupabaseRepository("stock_movements"
     suspend fun getMovementsByDateRange(
         startDate: Long,
         endDate: Long,
-        siteId: Long? = null
+        siteId: String? = null
     ): List<StockMovementDto> {
         return supabase.from(tableName).select {
             filter {
@@ -103,26 +103,26 @@ class StockMovementSupabaseRepository : BaseSupabaseRepository("stock_movements"
 
 class InventorySupabaseRepository : BaseSupabaseRepository("inventories") {
     suspend fun getAllInventories(): List<InventoryDto> = getAll()
-    suspend fun getInventoryById(id: Long): InventoryDto? = getById(id)
+    suspend fun getInventoryById(id: String): InventoryDto? = getById(id)
     suspend fun createInventory(inventory: InventoryDto): InventoryDto = create(inventory)
-    suspend fun updateInventory(id: Long, inventory: InventoryDto): InventoryDto = update(id, inventory)
-    suspend fun deleteInventory(id: Long) = delete(id)
+    suspend fun updateInventory(id: String, inventory: InventoryDto): InventoryDto = update(id, inventory)
+    suspend fun deleteInventory(id: String) = delete(id)
 
-    suspend fun getInventoriesByProduct(productId: Long): List<InventoryDto> {
+    suspend fun getInventoriesByProduct(productId: String): List<InventoryDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
             order(column = "count_date", order = Order.DESCENDING)
         }.decodeList()
     }
 
-    suspend fun getInventoriesBySite(siteId: Long): List<InventoryDto> {
+    suspend fun getInventoriesBySite(siteId: String): List<InventoryDto> {
         return supabase.from(tableName).select {
             filter { eq("site_id", siteId) }
             order(column = "count_date", order = Order.DESCENDING)
         }.decodeList()
     }
 
-    suspend fun getInventoriesWithDiscrepancy(siteId: Long? = null): List<InventoryDto> {
+    suspend fun getInventoriesWithDiscrepancy(siteId: String? = null): List<InventoryDto> {
         return supabase.from(tableName).select {
             filter {
                 neq("discrepancy", 0.0)
@@ -134,7 +134,7 @@ class InventorySupabaseRepository : BaseSupabaseRepository("inventories") {
         }.decodeList()
     }
 
-    suspend fun getLatestInventory(productId: Long, siteId: Long): InventoryDto? {
+    suspend fun getLatestInventory(productId: String, siteId: String): InventoryDto? {
         return supabase.from(tableName).select {
             filter {
                 eq("product_id", productId)
@@ -148,33 +148,33 @@ class InventorySupabaseRepository : BaseSupabaseRepository("inventories") {
 
 class ProductTransferSupabaseRepository : BaseSupabaseRepository("product_transfers") {
     suspend fun getAllTransfers(): List<ProductTransferDto> = getAll()
-    suspend fun getTransferById(id: Long): ProductTransferDto? = getById(id)
+    suspend fun getTransferById(id: String): ProductTransferDto? = getById(id)
     suspend fun createTransfer(transfer: ProductTransferDto): ProductTransferDto = create(transfer)
-    suspend fun updateTransfer(id: Long, transfer: ProductTransferDto): ProductTransferDto = update(id, transfer)
-    suspend fun deleteTransfer(id: Long) = delete(id)
+    suspend fun updateTransfer(id: String, transfer: ProductTransferDto): ProductTransferDto = update(id, transfer)
+    suspend fun deleteTransfer(id: String) = delete(id)
 
-    suspend fun getTransfersFromSite(siteId: Long): List<ProductTransferDto> {
+    suspend fun getTransfersFromSite(siteId: String): List<ProductTransferDto> {
         return supabase.from(tableName).select {
             filter { eq("from_site_id", siteId) }
             order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
-    suspend fun getTransfersToSite(siteId: Long): List<ProductTransferDto> {
+    suspend fun getTransfersToSite(siteId: String): List<ProductTransferDto> {
         return supabase.from(tableName).select {
             filter { eq("to_site_id", siteId) }
             order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
-    suspend fun getTransfersByProduct(productId: Long): List<ProductTransferDto> {
+    suspend fun getTransfersByProduct(productId: String): List<ProductTransferDto> {
         return supabase.from(tableName).select {
             filter { eq("product_id", productId) }
             order(column = "date", order = Order.DESCENDING)
         }.decodeList()
     }
 
-    suspend fun getTransfersBetweenSites(fromSiteId: Long, toSiteId: Long): List<ProductTransferDto> {
+    suspend fun getTransfersBetweenSites(fromSiteId: String, toSiteId: String): List<ProductTransferDto> {
         return supabase.from(tableName).select {
             filter {
                 eq("from_site_id", fromSiteId)

--- a/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
+++ b/app/src/main/java/com/medistock/data/remote/repository/UserRepositories.kt
@@ -6,10 +6,10 @@ import io.github.jan.supabase.postgrest.from
 
 class UserSupabaseRepository : BaseSupabaseRepository("app_users") {
     suspend fun getAllUsers(): List<AppUserDto> = getAll()
-    suspend fun getUserById(id: Long): AppUserDto? = getById(id)
+    suspend fun getUserById(id: String): AppUserDto? = getById(id)
     suspend fun createUser(user: AppUserDto): AppUserDto = create(user)
-    suspend fun updateUser(id: Long, user: AppUserDto): AppUserDto = update(id, user)
-    suspend fun deleteUser(id: Long) = delete(id)
+    suspend fun updateUser(id: String, user: AppUserDto): AppUserDto = update(id, user)
+    suspend fun deleteUser(id: String) = delete(id)
 
     suspend fun getUserByUsername(username: String): AppUserDto? {
         return supabase.from(tableName).select {
@@ -39,18 +39,18 @@ class UserSupabaseRepository : BaseSupabaseRepository("app_users") {
 
 class UserPermissionSupabaseRepository : BaseSupabaseRepository("user_permissions") {
     suspend fun getAllPermissions(): List<UserPermissionDto> = getAll()
-    suspend fun getPermissionById(id: Long): UserPermissionDto? = getById(id)
+    suspend fun getPermissionById(id: String): UserPermissionDto? = getById(id)
     suspend fun createPermission(permission: UserPermissionDto): UserPermissionDto = create(permission)
-    suspend fun updatePermission(id: Long, permission: UserPermissionDto): UserPermissionDto = update(id, permission)
-    suspend fun deletePermission(id: Long) = delete(id)
+    suspend fun updatePermission(id: String, permission: UserPermissionDto): UserPermissionDto = update(id, permission)
+    suspend fun deletePermission(id: String) = delete(id)
 
-    suspend fun getPermissionsByUser(userId: Long): List<UserPermissionDto> {
+    suspend fun getPermissionsByUser(userId: String): List<UserPermissionDto> {
         return supabase.from(tableName).select {
             filter { eq("user_id", userId) }
         }.decodeList()
     }
 
-    suspend fun getPermissionByUserAndModule(userId: Long, module: String): UserPermissionDto? {
+    suspend fun getPermissionByUserAndModule(userId: String, module: String): UserPermissionDto? {
         return supabase.from(tableName).select {
             filter {
                 eq("user_id", userId)
@@ -59,7 +59,7 @@ class UserPermissionSupabaseRepository : BaseSupabaseRepository("user_permission
         }.decodeList<UserPermissionDto>().firstOrNull()
     }
 
-    suspend fun hasPermission(userId: Long, module: String, action: String): Boolean {
+    suspend fun hasPermission(userId: String, module: String, action: String): Boolean {
         val permission = getPermissionByUserAndModule(userId, module) ?: return false
 
         return when (action) {
@@ -71,7 +71,7 @@ class UserPermissionSupabaseRepository : BaseSupabaseRepository("user_permission
         }
     }
 
-    suspend fun deleteAllUserPermissions(userId: Long) {
+    suspend fun deleteAllUserPermissions(userId: String) {
         supabase.from(tableName).delete {
             filter { eq("user_id", userId) }
         }

--- a/app/src/main/java/com/medistock/data/repository/AuditedProductRepository.kt
+++ b/app/src/main/java/com/medistock/data/repository/AuditedProductRepository.kt
@@ -18,12 +18,13 @@ class AuditedProductRepository(private val context: Context) {
 
     fun getAll(): Flow<List<Product>> = productDao.getAll()
 
-    fun getById(productId: Long): Flow<Product?> = productDao.getById(productId)
+    fun getById(productId: String): Flow<Product?> = productDao.getById(productId)
 
-    fun getProductsForSite(siteId: Long): Flow<List<Product>> = productDao.getProductsForSite(siteId)
+    fun getProductsForSite(siteId: String): Flow<List<Product>> = productDao.getProductsForSite(siteId)
 
-    fun insert(product: Product): Long {
-        val productId = productDao.insert(product)
+    fun insert(product: Product): String {
+        productDao.insert(product)
+        val productId = product.id
 
         // Log the insert action
         auditLogger.logInsert(

--- a/app/src/main/java/com/medistock/data/repository/AuditedPurchaseBatchRepository.kt
+++ b/app/src/main/java/com/medistock/data/repository/AuditedPurchaseBatchRepository.kt
@@ -15,8 +15,9 @@ class AuditedPurchaseBatchRepository(private val context: Context) {
     private val auditLogger = AuditLogger.getInstance(context)
     private val authManager = AuthManager.getInstance(context)
 
-    fun insert(batch: PurchaseBatch): Long {
-        val batchId = purchaseBatchDao.insert(batch)
+    fun insert(batch: PurchaseBatch): String {
+        purchaseBatchDao.insert(batch)
+        val batchId = batch.id
 
         // Log the insert action
         auditLogger.logInsert(

--- a/app/src/main/java/com/medistock/data/repository/AuditedSaleRepository.kt
+++ b/app/src/main/java/com/medistock/data/repository/AuditedSaleRepository.kt
@@ -15,8 +15,9 @@ class AuditedSaleRepository(private val context: Context) {
     private val auditLogger = AuditLogger.getInstance(context)
     private val authManager = AuthManager.getInstance(context)
 
-    fun insert(sale: Sale): Long {
-        val saleId = saleDao.insert(sale)
+    fun insert(sale: Sale): String {
+        saleDao.insert(sale)
+        val saleId = sale.id
 
         // Log the insert action
         auditLogger.logInsert(

--- a/app/src/main/java/com/medistock/data/repository/AuditedUserRepository.kt
+++ b/app/src/main/java/com/medistock/data/repository/AuditedUserRepository.kt
@@ -15,8 +15,9 @@ class AuditedUserRepository(private val context: Context) {
     private val auditLogger = AuditLogger.getInstance(context)
     private val authManager = AuthManager.getInstance(context)
 
-    fun insert(user: User): Long {
-        val userId = userDao.insertUser(user)
+    fun insert(user: User): String {
+        userDao.insertUser(user)
+        val userId = user.id
 
         // Log the insert action (don't log password)
         auditLogger.logInsert(

--- a/app/src/main/java/com/medistock/ui/MainActivity.kt
+++ b/app/src/main/java/com/medistock/ui/MainActivity.kt
@@ -36,9 +36,11 @@ class MainActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             val siteId = PrefsHelper.getActiveSiteId(this@MainActivity)
-            db.productDao().getProductsWithCategoryForSite(siteId).collect { products ->
-                adapter = ProductWithCategoryAdapter(products)
-                recyclerView.adapter = adapter
+            if (!siteId.isNullOrBlank()) {
+                db.productDao().getProductsWithCategoryForSite(siteId).collect { products ->
+                    adapter = ProductWithCategoryAdapter(products)
+                    recyclerView.adapter = adapter
+                }
             }
         }
     }

--- a/app/src/main/java/com/medistock/ui/adapters/SaleItemAdapter.kt
+++ b/app/src/main/java/com/medistock/ui/adapters/SaleItemAdapter.kt
@@ -52,7 +52,7 @@ class SaleItemAdapter(
 
     fun getItems(): List<SaleItem> = items
 
-    fun getTotalQuantityForProduct(productId: Long): Double {
+    fun getTotalQuantityForProduct(productId: String): Double {
         return items.filter { it.productId == productId }.sumOf { it.quantity }
     }
 

--- a/app/src/main/java/com/medistock/ui/auth/LoginActivity.kt
+++ b/app/src/main/java/com/medistock/ui/auth/LoginActivity.kt
@@ -119,7 +119,7 @@ class LoginActivity : AppCompatActivity() {
                     createdBy = "system",
                     updatedBy = "system"
                 )
-                val userId = db.userDao().insertUser(adminUser)
+                db.userDao().insertUser(adminUser)
 
                 // Give admin all permissions (though admin check bypasses this)
                 val modules = listOf(
@@ -129,7 +129,7 @@ class LoginActivity : AppCompatActivity() {
                 )
                 val permissions = modules.map { module ->
                     UserPermission(
-                        userId = userId,
+                        userId = adminUser.id,
                         module = module,
                         canView = true,
                         canCreate = true,

--- a/app/src/main/java/com/medistock/ui/category/CategoryAddEditActivity.kt
+++ b/app/src/main/java/com/medistock/ui/category/CategoryAddEditActivity.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 
 class CategoryAddEditActivity : AppCompatActivity() {
     private lateinit var db: AppDatabase
-    private var categoryId: Long? = null
+    private var categoryId: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,7 +30,7 @@ class CategoryAddEditActivity : AppCompatActivity() {
         val btnSave = findViewById<Button>(R.id.btnSaveCategory)
         val btnDelete = findViewById<Button>(R.id.btnDeleteCategory)
 
-        categoryId = intent.getLongExtra("CATEGORY_ID", -1).takeIf { it != -1L }
+        categoryId = intent.getStringExtra("CATEGORY_ID")?.takeIf { it.isNotBlank() }
         if (categoryId != null) {
             supportActionBar?.title = "Edit Category"
             btnDelete.visibility = View.VISIBLE

--- a/app/src/main/java/com/medistock/ui/movement/StockMovementActivity.kt
+++ b/app/src/main/java/com/medistock/ui/movement/StockMovementActivity.kt
@@ -52,18 +52,20 @@ class StockMovementActivity : AppCompatActivity() {
                     val latestPrice = db.productPriceDao().getLatestPrice(product.id).first()
                     if (latestPrice != null) {
                         val siteId = com.medistock.util.PrefsHelper.getActiveSiteId(this@StockMovementActivity)
-                    db.stockMovementDao().insert(
-                            StockMovement(
-                                productId = product.id,
-                                type = type,
-                                quantity = quantityInBaseUnit,
-                                date = System.currentTimeMillis(),
-                                purchasePriceAtMovement = latestPrice.purchasePrice,
-                                sellingPriceAtMovement = latestPrice.sellingPrice,
-                            siteId = siteId
+                        if (!siteId.isNullOrBlank()) {
+                            db.stockMovementDao().insert(
+                                StockMovement(
+                                    productId = product.id,
+                                    type = type,
+                                    quantity = quantityInBaseUnit,
+                                    date = System.currentTimeMillis(),
+                                    purchasePriceAtMovement = latestPrice.purchasePrice,
+                                    sellingPriceAtMovement = latestPrice.sellingPrice,
+                                    siteId = siteId
+                                )
                             )
-                        )
-                        finish()
+                            finish()
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/medistock/ui/movement/StockMovementListActivity.kt
+++ b/app/src/main/java/com/medistock/ui/movement/StockMovementListActivity.kt
@@ -25,6 +25,7 @@ class StockMovementListActivity : AppCompatActivity() {
         val siteId = PrefsHelper.getActiveSiteId(this)
 
         lifecycleScope.launch {
+            if (siteId.isNullOrBlank()) return@launch
             val products = db.productDao().getProductsForSite(siteId).first().associateBy { it.id }
             val movements = db.stockMovementDao().getAllForSite(siteId).first()
             val items = movements.map {

--- a/app/src/main/java/com/medistock/ui/packaging/PackagingTypeAddEditActivity.kt
+++ b/app/src/main/java/com/medistock/ui/packaging/PackagingTypeAddEditActivity.kt
@@ -13,7 +13,7 @@ import com.medistock.ui.viewmodel.PackagingTypeViewModel
 class PackagingTypeAddEditActivity : AppCompatActivity() {
 
     private lateinit var viewModel: PackagingTypeViewModel
-    private var packagingTypeId: Long? = null
+    private var packagingTypeId: String? = null
     private var existingPackagingType: PackagingType? = null
 
     private lateinit var editName: EditText
@@ -29,7 +29,7 @@ class PackagingTypeAddEditActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_packaging_type_add_edit)
 
-        packagingTypeId = intent.getLongExtra("PACKAGING_TYPE_ID", -1).takeIf { it != -1L }
+        packagingTypeId = intent.getStringExtra("PACKAGING_TYPE_ID")?.takeIf { it.isNotBlank() }
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.title = if (packagingTypeId == null) {
@@ -143,19 +143,34 @@ class PackagingTypeAddEditActivity : AppCompatActivity() {
 
         val isActive = checkboxActive.isChecked
 
-        val packagingType = PackagingType(
-            id = packagingTypeId ?: 0,
-            name = name,
-            level1Name = level1Name,
-            level2Name = level2Name,
-            defaultConversionFactor = conversionFactor,
-            isActive = isActive,
-            displayOrder = existingPackagingType?.displayOrder ?: 0,
-            createdAt = existingPackagingType?.createdAt ?: System.currentTimeMillis(),
-            updatedAt = System.currentTimeMillis(),
-            createdBy = existingPackagingType?.createdBy,
-            updatedBy = null // TODO: Add current user
-        )
+        val packagingType = if (packagingTypeId == null) {
+            PackagingType(
+                name = name,
+                level1Name = level1Name,
+                level2Name = level2Name,
+                defaultConversionFactor = conversionFactor,
+                isActive = isActive,
+                displayOrder = existingPackagingType?.displayOrder ?: 0,
+                createdAt = existingPackagingType?.createdAt ?: System.currentTimeMillis(),
+                updatedAt = System.currentTimeMillis(),
+                createdBy = existingPackagingType?.createdBy,
+                updatedBy = null // TODO: Add current user
+            )
+        } else {
+            PackagingType(
+                id = packagingTypeId!!,
+                name = name,
+                level1Name = level1Name,
+                level2Name = level2Name,
+                defaultConversionFactor = conversionFactor,
+                isActive = isActive,
+                displayOrder = existingPackagingType?.displayOrder ?: 0,
+                createdAt = existingPackagingType?.createdAt ?: System.currentTimeMillis(),
+                updatedAt = System.currentTimeMillis(),
+                createdBy = existingPackagingType?.createdBy,
+                updatedBy = null // TODO: Add current user
+            )
+        }
 
         val callback = {
             runOnUiThread {

--- a/app/src/main/java/com/medistock/ui/packaging/PackagingTypeListActivity.kt
+++ b/app/src/main/java/com/medistock/ui/packaging/PackagingTypeListActivity.kt
@@ -68,7 +68,7 @@ class PackagingTypeListActivity : AppCompatActivity() {
         }
     }
 
-    private fun confirmDelete(id: Long, name: String) {
+    private fun confirmDelete(id: String, name: String) {
         viewModel.isUsedByProducts(id) { isUsed ->
             runOnUiThread {
                 if (isUsed) {
@@ -103,7 +103,7 @@ class PackagingTypeListActivity : AppCompatActivity() {
         }
     }
 
-    private fun toggleActive(id: Long, currentlyActive: Boolean) {
+    private fun toggleActive(id: String, currentlyActive: Boolean) {
         val callback = {
             runOnUiThread {
                 val message = if (currentlyActive) "Deactivated" else "Activated"

--- a/app/src/main/java/com/medistock/ui/product/ProductAddActivity.kt
+++ b/app/src/main/java/com/medistock/ui/product/ProductAddActivity.kt
@@ -32,12 +32,12 @@ class ProductAddActivity : AppCompatActivity() {
     private lateinit var btnSave: Button
 
     private var categories: List<Category> = emptyList()
-    private var selectedCategoryId: Long = 0L
+    private var selectedCategoryId: String? = null
     private var selectedUnit: String = "Bottle"
     private var selectedMarginType: String = "percentage"
     private var enteredMarginValue: Double = 0.0
     private var enteredUnitVolume: Double = 0.0
-    private var currentSiteId: Long = 0L
+    private var currentSiteId: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -109,7 +109,7 @@ class ProductAddActivity : AppCompatActivity() {
 
         spinnerCategory.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>, view: android.view.View?, position: Int, id: Long) {
-                selectedCategoryId = categories.getOrNull(position)?.id ?: 0L
+                selectedCategoryId = categories.getOrNull(position)?.id
             }
             override fun onNothingSelected(parent: AdapterView<*>) {}
         }
@@ -156,7 +156,7 @@ class ProductAddActivity : AppCompatActivity() {
                 Toast.makeText(this, getString(R.string.error_enter_product_name), Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
-            if (selectedCategoryId == 0L) {
+            if (selectedCategoryId == null) {
                 Toast.makeText(this, getString(R.string.error_select_category), Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
@@ -166,7 +166,7 @@ class ProductAddActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
-            if (currentSiteId == 0L) {
+            if (currentSiteId.isNullOrBlank()) {
                 Toast.makeText(this, "No active site. Please select a site first.", Toast.LENGTH_LONG).show()
                 return@setOnClickListener
             }
@@ -197,7 +197,7 @@ class ProductAddActivity : AppCompatActivity() {
                 marginType = selectedMarginType,
                 marginValue = enteredMarginValue,
                 unitVolume = enteredUnitVolume,
-                siteId = currentSiteId
+                siteId = currentSiteId!!
             )
 
             lifecycleScope.launch {

--- a/app/src/main/java/com/medistock/ui/product/ProductListActivity.kt
+++ b/app/src/main/java/com/medistock/ui/product/ProductListActivity.kt
@@ -50,6 +50,7 @@ class ProductListActivity : AppCompatActivity() {
 
     private fun loadProducts() {
         val siteId = PrefsHelper.getActiveSiteId(this)
+        if (siteId.isNullOrBlank()) return
         CoroutineScope(Dispatchers.IO).launch {
             val products = db.productDao().getProductsForSite(siteId).first()
             runOnUiThread { adapter.submitList(products) }

--- a/app/src/main/java/com/medistock/ui/purchase/PurchaseActivity.kt
+++ b/app/src/main/java/com/medistock/ui/purchase/PurchaseActivity.kt
@@ -32,9 +32,9 @@ class PurchaseActivity : AppCompatActivity() {
 
     private var sites: List<com.medistock.data.entities.Site> = emptyList()
     private var products: List<Product> = emptyList()
-    private var selectedProductId: Long = 0L
+    private var selectedProductId: String? = null
     private var selectedProduct: Product? = null
-    private var selectedSiteId: Long = 0L
+    private var selectedSiteId: String? = null
     private var isManualSellingPrice = false // Track if user manually modified selling price
 
     private val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
@@ -74,7 +74,7 @@ class PurchaseActivity : AppCompatActivity() {
             override fun onItemSelected(parent: AdapterView<*>, view: android.view.View?, position: Int, id: Long) {
                 if (position >= 0 && position < products.size) {
                     selectedProduct = products[position]
-                    selectedProductId = selectedProduct?.id ?: 0L
+                    selectedProductId = selectedProduct?.id
                     updateMarginInfo()
                     calculateSellingPrice()
                 }
@@ -195,8 +195,12 @@ class PurchaseActivity : AppCompatActivity() {
             return
         }
 
-        if (selectedProductId == 0L) {
+        if (selectedProductId == null) {
             Toast.makeText(this, "Select a product", Toast.LENGTH_SHORT).show()
+            return
+        }
+        if (selectedSiteId.isNullOrBlank()) {
+            Toast.makeText(this, "Select a site", Toast.LENGTH_SHORT).show()
             return
         }
 
@@ -215,8 +219,8 @@ class PurchaseActivity : AppCompatActivity() {
 
             // Create purchase batch
             val batch = PurchaseBatch(
-                productId = selectedProductId,
-                siteId = selectedSiteId,
+                productId = selectedProductId!!,
+                siteId = selectedSiteId!!,
                 batchNumber = batchNumber.ifEmpty { null }, // Optional, null if not provided
                 purchaseDate = System.currentTimeMillis(),
                 initialQuantity = quantity,
@@ -230,19 +234,19 @@ class PurchaseActivity : AppCompatActivity() {
 
             // Create stock movement (entry)
             val movement = StockMovement(
-                productId = selectedProductId,
+                productId = selectedProductId!!,
                 type = "in",
                 quantity = quantity,
                 date = System.currentTimeMillis(),
                 purchasePriceAtMovement = purchasePrice,
                 sellingPriceAtMovement = sellingPrice,
-                siteId = selectedSiteId
+                siteId = selectedSiteId!!
             )
             db.stockMovementDao().insert(movement)
 
             // Update product price record
             val priceRecord = ProductPrice(
-                productId = selectedProductId,
+                productId = selectedProductId!!,
                 effectiveDate = System.currentTimeMillis(),
                 purchasePrice = purchasePrice,
                 sellingPrice = sellingPrice,

--- a/app/src/main/java/com/medistock/ui/sales/SaleListActivity.kt
+++ b/app/src/main/java/com/medistock/ui/sales/SaleListActivity.kt
@@ -60,7 +60,8 @@ class SaleListActivity : AppCompatActivity() {
         loadSales(siteId)
     }
 
-    private fun loadSales(siteId: Long) {
+    private fun loadSales(siteId: String?) {
+        if (siteId.isNullOrBlank()) return
         lifecycleScope.launch(Dispatchers.IO) {
             db.saleDao().getAllWithItemsForSite(siteId).collect { sales ->
                 withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/medistock/ui/site/SiteAddEditActivity.kt
+++ b/app/src/main/java/com/medistock/ui/site/SiteAddEditActivity.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 
 class SiteAddEditActivity : AppCompatActivity() {
     private lateinit var db: AppDatabase
-    private var siteId: Long? = null
+    private var siteId: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,7 +30,7 @@ class SiteAddEditActivity : AppCompatActivity() {
         val btnSave = findViewById<Button>(R.id.btnSaveSite)
         val btnDelete = findViewById<Button>(R.id.btnDeleteSite)
 
-        siteId = intent.getLongExtra("SITE_ID", -1).takeIf { it != -1L }
+        siteId = intent.getStringExtra("SITE_ID")?.takeIf { it.isNotBlank() }
         if (siteId != null) {
             supportActionBar?.title = "Edit Site"
             btnDelete.visibility = View.VISIBLE

--- a/app/src/main/java/com/medistock/ui/transfer/TransferAdapter.kt
+++ b/app/src/main/java/com/medistock/ui/transfer/TransferAdapter.kt
@@ -15,8 +15,8 @@ import java.util.*
 
 class TransferAdapter(
     private val transfers: List<ProductTransfer>,
-    private val products: Map<Long, Product>,
-    private val sites: Map<Long, Site>,
+    private val products: Map<String, Product>,
+    private val sites: Map<String, Site>,
     private val onEditClick: (ProductTransfer) -> Unit,
     private val onDeleteClick: (ProductTransfer) -> Unit
 ) : RecyclerView.Adapter<TransferAdapter.ViewHolder>() {

--- a/app/src/main/java/com/medistock/ui/transfer/TransferItem.kt
+++ b/app/src/main/java/com/medistock/ui/transfer/TransferItem.kt
@@ -1,7 +1,7 @@
 package com.medistock.ui.transfer
 
 data class TransferItem(
-    val productId: Long,
+    val productId: String,
     val productName: String,
     val unit: String,
     var quantity: Double

--- a/app/src/main/java/com/medistock/ui/transfer/TransferItemAdapter.kt
+++ b/app/src/main/java/com/medistock/ui/transfer/TransferItemAdapter.kt
@@ -50,7 +50,7 @@ class TransferItemAdapter(
         }
     }
 
-    fun getTotalQuantityForProduct(productId: Long): Double {
+    fun getTotalQuantityForProduct(productId: String): Double {
         return items.filter { it.productId == productId }.sumOf { it.quantity }
     }
 

--- a/app/src/main/java/com/medistock/ui/viewmodel/AuditHistoryViewModel.kt
+++ b/app/src/main/java/com/medistock/ui/viewmodel/AuditHistoryViewModel.kt
@@ -52,7 +52,7 @@ class AuditHistoryViewModel(application: Application) : AndroidViewModel(applica
         }
     }
 
-    fun loadByEntity(entityType: String, entityId: Long) {
+    fun loadByEntity(entityType: String, entityId: String) {
         viewModelScope.launch(Dispatchers.IO) {
             _isLoading.value = true
             try {
@@ -74,7 +74,7 @@ class AuditHistoryViewModel(application: Application) : AndroidViewModel(applica
         }
     }
 
-    fun loadBySite(siteId: Long) {
+    fun loadBySite(siteId: String) {
         viewModelScope.launch(Dispatchers.IO) {
             _isLoading.value = true
             try {
@@ -100,7 +100,7 @@ class AuditHistoryViewModel(application: Application) : AndroidViewModel(applica
         entityType: String?,
         actionType: String?,
         username: String?,
-        siteId: Long?,
+        siteId: String?,
         startTime: Long?,
         endTime: Long?,
         limit: Int = 100,

--- a/app/src/main/java/com/medistock/ui/viewmodel/PackagingTypeViewModel.kt
+++ b/app/src/main/java/com/medistock/ui/viewmodel/PackagingTypeViewModel.kt
@@ -42,17 +42,17 @@ class PackagingTypeViewModel(application: Application) : AndroidViewModel(applic
         }
     }
 
-    fun getById(id: Long, callback: (PackagingType?) -> Unit) {
+    fun getById(id: String, callback: (PackagingType?) -> Unit) {
         viewModelScope.launch(Dispatchers.IO) {
             val result = packagingTypeDao.getByIdSync(id)
             callback(result)
         }
     }
 
-    fun insert(packagingType: PackagingType, callback: (Long) -> Unit) {
+    fun insert(packagingType: PackagingType, callback: (String) -> Unit) {
         viewModelScope.launch(Dispatchers.IO) {
-            val id = packagingTypeDao.insert(packagingType)
-            callback(id)
+            packagingTypeDao.insert(packagingType)
+            callback(packagingType.id)
         }
     }
 
@@ -70,21 +70,21 @@ class PackagingTypeViewModel(application: Application) : AndroidViewModel(applic
         }
     }
 
-    fun deactivate(id: Long, callback: () -> Unit) {
+    fun deactivate(id: String, callback: () -> Unit) {
         viewModelScope.launch(Dispatchers.IO) {
             packagingTypeDao.deactivate(id)
             callback()
         }
     }
 
-    fun activate(id: Long, callback: () -> Unit) {
+    fun activate(id: String, callback: () -> Unit) {
         viewModelScope.launch(Dispatchers.IO) {
             packagingTypeDao.activate(id)
             callback()
         }
     }
 
-    fun isUsedByProducts(packagingTypeId: Long, callback: (Boolean) -> Unit) {
+    fun isUsedByProducts(packagingTypeId: String, callback: (Boolean) -> Unit) {
         viewModelScope.launch(Dispatchers.IO) {
             val result = packagingTypeDao.isUsedByProducts(packagingTypeId)
             callback(result)

--- a/app/src/main/java/com/medistock/ui/viewmodel/ProductViewModel.kt
+++ b/app/src/main/java/com/medistock/ui/viewmodel/ProductViewModel.kt
@@ -40,7 +40,7 @@ class ProductViewModel(application: Application) : AndroidViewModel(application)
 
     fun addProductWithPrice(product: Product, purchasePrice: Double) {
         viewModelScope.launch(Dispatchers.IO) {
-            val productId = db.productDao().insert(product)
+            db.productDao().insert(product)
             val sellingPrice = when (product.marginType) {
                 "fixed" -> purchasePrice + (product.marginValue ?: 0.0)
                 "percentage" -> purchasePrice * (1 + (product.marginValue ?: 0.0) / 100)
@@ -48,7 +48,7 @@ class ProductViewModel(application: Application) : AndroidViewModel(application)
             }
             db.productPriceDao().insert(
                 ProductPrice(
-                    productId = productId,
+                    productId = product.id,
                     effectiveDate = System.currentTimeMillis(),
                     purchasePrice = purchasePrice,
                     sellingPrice = sellingPrice,
@@ -59,7 +59,7 @@ class ProductViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
-    fun loadProductsForSite(siteId: Long) {
+    fun loadProductsForSite(siteId: String) {
         viewModelScope.launch(Dispatchers.IO) {
             _products.value = db.productDao().getProductsForSite(siteId).first()
         }

--- a/app/src/main/java/com/medistock/util/AuditLogger.kt
+++ b/app/src/main/java/com/medistock/util/AuditLogger.kt
@@ -35,10 +35,10 @@ class AuditLogger(context: Context) {
      */
     fun logInsert(
         entityType: String,
-        entityId: Long,
+        entityId: String,
         newValues: Map<String, String>,
         username: String,
-        siteId: Long? = null,
+        siteId: String? = null,
         description: String? = null
     ) {
         executor.execute {
@@ -63,10 +63,10 @@ class AuditLogger(context: Context) {
      */
     fun logUpdate(
         entityType: String,
-        entityId: Long,
+        entityId: String,
         changes: Map<String, Pair<String?, String?>>, // Map of fieldName to (oldValue, newValue)
         username: String,
-        siteId: Long? = null,
+        siteId: String? = null,
         description: String? = null
     ) {
         executor.execute {
@@ -94,10 +94,10 @@ class AuditLogger(context: Context) {
      */
     fun logDelete(
         entityType: String,
-        entityId: Long,
+        entityId: String,
         oldValues: Map<String, String>,
         username: String,
-        siteId: Long? = null,
+        siteId: String? = null,
         description: String? = null
     ) {
         executor.execute {
@@ -122,11 +122,11 @@ class AuditLogger(context: Context) {
      */
     fun logAction(
         entityType: String,
-        entityId: Long,
+        entityId: String,
         actionType: String,
         description: String,
         username: String,
-        siteId: Long? = null
+        siteId: String? = null
     ) {
         executor.execute {
             val auditEntry = AuditHistory(

--- a/app/src/main/java/com/medistock/util/AuthManager.kt
+++ b/app/src/main/java/com/medistock/util/AuthManager.kt
@@ -33,7 +33,7 @@ class AuthManager(context: Context) {
      */
     fun login(user: User) {
         prefs.edit().apply {
-            putLong(KEY_USER_ID, user.id)
+            putString(KEY_USER_ID, user.id)
             putString(KEY_USERNAME, user.username)
             putString(KEY_FULL_NAME, user.fullName)
             putBoolean(KEY_IS_ADMIN, user.isAdmin)
@@ -59,8 +59,8 @@ class AuthManager(context: Context) {
     /**
      * Get current user ID
      */
-    fun getUserId(): Long {
-        return prefs.getLong(KEY_USER_ID, -1)
+    fun getUserId(): String? {
+        return prefs.getString(KEY_USER_ID, null)
     }
 
     /**

--- a/app/src/main/java/com/medistock/util/BatchTransferHelper.kt
+++ b/app/src/main/java/com/medistock/util/BatchTransferHelper.kt
@@ -14,9 +14,9 @@ class BatchTransferHelper(private val batchDao: PurchaseBatchDao) {
      * Returns list of batch transfers (source batch info for creating destination batches).
      */
     fun transferBatchesFIFO(
-        productId: Long,
-        fromSiteId: Long,
-        toSiteId: Long,
+        productId: String,
+        fromSiteId: String,
+        toSiteId: String,
         totalQuantity: Double,
         currentUser: String
     ): List<BatchTransferInfo> {

--- a/app/src/main/java/com/medistock/util/PermissionManager.kt
+++ b/app/src/main/java/com/medistock/util/PermissionManager.kt
@@ -35,7 +35,8 @@ class PermissionManager(
     suspend fun canView(module: String): Boolean {
         if (authManager.isAdmin()) return true
         return withContext(Dispatchers.IO) {
-            val permission = userPermissionDao.getPermissionForModule(authManager.getUserId(), module)
+            val userId = authManager.getUserId() ?: return@withContext false
+            val permission = userPermissionDao.getPermissionForModule(userId, module)
             permission?.canView ?: false
         }
     }
@@ -46,7 +47,8 @@ class PermissionManager(
     suspend fun canCreate(module: String): Boolean {
         if (authManager.isAdmin()) return true
         return withContext(Dispatchers.IO) {
-            val permission = userPermissionDao.getPermissionForModule(authManager.getUserId(), module)
+            val userId = authManager.getUserId() ?: return@withContext false
+            val permission = userPermissionDao.getPermissionForModule(userId, module)
             permission?.canCreate ?: false
         }
     }
@@ -57,7 +59,8 @@ class PermissionManager(
     suspend fun canEdit(module: String): Boolean {
         if (authManager.isAdmin()) return true
         return withContext(Dispatchers.IO) {
-            val permission = userPermissionDao.getPermissionForModule(authManager.getUserId(), module)
+            val userId = authManager.getUserId() ?: return@withContext false
+            val permission = userPermissionDao.getPermissionForModule(userId, module)
             permission?.canEdit ?: false
         }
     }
@@ -68,7 +71,8 @@ class PermissionManager(
     suspend fun canDelete(module: String): Boolean {
         if (authManager.isAdmin()) return true
         return withContext(Dispatchers.IO) {
-            val permission = userPermissionDao.getPermissionForModule(authManager.getUserId(), module)
+            val userId = authManager.getUserId() ?: return@withContext false
+            val permission = userPermissionDao.getPermissionForModule(userId, module)
             permission?.canDelete ?: false
         }
     }
@@ -78,7 +82,8 @@ class PermissionManager(
      */
     suspend fun getUserPermissions(): List<UserPermission> {
         return withContext(Dispatchers.IO) {
-            userPermissionDao.getPermissionsForUser(authManager.getUserId())
+            val userId = authManager.getUserId() ?: return@withContext emptyList()
+            userPermissionDao.getPermissionsForUser(userId)
         }
     }
 }

--- a/app/src/main/java/com/medistock/util/PrefsHelper.kt
+++ b/app/src/main/java/com/medistock/util/PrefsHelper.kt
@@ -6,16 +6,16 @@ object PrefsHelper {
     private const val PREF_NAME = "medistock_prefs"
     private const val KEY_ACTIVE_SITE_ID = "active_site_id"
 
-    fun saveActiveSiteId(context: Context, siteId: Long) {
+    fun saveActiveSiteId(context: Context, siteId: String) {
         context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
             .edit()
-            .putLong(KEY_ACTIVE_SITE_ID, siteId)
+            .putString(KEY_ACTIVE_SITE_ID, siteId)
             .apply()
     }
 
-    fun getActiveSiteId(context: Context): Long {
+    fun getActiveSiteId(context: Context): String? {
         return context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
-            .getLong(KEY_ACTIVE_SITE_ID, -1L)
+            .getString(KEY_ACTIVE_SITE_ID, null)
     }
 
     fun clearActiveSite(context: Context) {

--- a/supabase-rls-policies.sql
+++ b/supabase-rls-policies.sql
@@ -150,28 +150,28 @@ DROP POLICY IF EXISTS "Allow all operations on products" ON products;
 CREATE POLICY "Users can view products from their site"
   ON products FOR SELECT
   USING (
-    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::bigint
+    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::uuid
   );
 
 CREATE POLICY "Users can create products for their site"
   ON products FOR INSERT
   WITH CHECK (
-    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::bigint
+    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::uuid
   );
 
 CREATE POLICY "Users can update products from their site"
   ON products FOR UPDATE
   USING (
-    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::bigint
+    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::uuid
   )
   WITH CHECK (
-    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::bigint
+    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::uuid
   );
 
 CREATE POLICY "Users can delete products from their site"
   ON products FOR DELETE
   USING (
-    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::bigint
+    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::uuid
   );
 */
 
@@ -183,13 +183,13 @@ DROP POLICY IF EXISTS "Allow all operations on sales" ON sales;
 CREATE POLICY "Users can view sales from their site"
   ON sales FOR SELECT
   USING (
-    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::bigint
+    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::uuid
   );
 
 CREATE POLICY "Users can create sales for their site"
   ON sales FOR INSERT
   WITH CHECK (
-    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::bigint
+    site_id = (current_setting('request.jwt.claims', true)::json->>'site_id')::uuid
   );
 */
 
@@ -212,7 +212,7 @@ CREATE POLICY "Admins have full access to all tables"
 
 -- Fonction pour vérifier si un utilisateur a une permission spécifique
 CREATE OR REPLACE FUNCTION has_permission(
-  p_user_id BIGINT,
+  p_user_id UUID,
   p_module TEXT,
   p_action TEXT -- 'view', 'create', 'edit', 'delete'
 )

--- a/supabase-uuid-migration.sql
+++ b/supabase-uuid-migration.sql
@@ -1,0 +1,471 @@
+-- ============================================================================
+-- MEDISTOCK SUPABASE UUID MIGRATION
+-- Converts BIGSERIAL/BIGINT primary keys + foreign keys to UUIDs
+-- ============================================================================
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- --------------------------------------------------------------------------
+-- 1) PRIMARY TABLES: add UUID columns and backfill
+-- --------------------------------------------------------------------------
+
+ALTER TABLE sites ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE sites SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE categories ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE categories SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE packaging_types ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE packaging_types SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE app_users ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE app_users SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE customers SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE products ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE products SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE product_prices ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE product_prices SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE purchase_batches ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE purchase_batches SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE stock_movements ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE stock_movements SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE inventories ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE inventories SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE product_transfers ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE product_transfers SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE sales ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE sales SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE sale_items SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE sale_batch_allocations ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE sale_batch_allocations SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE product_sales ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE product_sales SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE audit_history ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE audit_history SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+ALTER TABLE user_permissions ADD COLUMN IF NOT EXISTS id_uuid UUID;
+UPDATE user_permissions SET id_uuid = uuid_generate_v4() WHERE id_uuid IS NULL;
+
+-- --------------------------------------------------------------------------
+-- 2) FOREIGN KEYS: add UUID FK columns + backfill using old IDs
+-- --------------------------------------------------------------------------
+
+ALTER TABLE user_permissions ADD COLUMN IF NOT EXISTS user_id_uuid UUID;
+UPDATE user_permissions up
+SET user_id_uuid = u.id_uuid
+FROM app_users u
+WHERE up.user_id = u.id;
+
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS site_id_uuid UUID;
+UPDATE customers c
+SET site_id_uuid = s.id_uuid
+FROM sites s
+WHERE c.site_id = s.id;
+
+ALTER TABLE products ADD COLUMN IF NOT EXISTS packaging_type_id_uuid UUID;
+UPDATE products p
+SET packaging_type_id_uuid = pt.id_uuid
+FROM packaging_types pt
+WHERE p.packaging_type_id = pt.id;
+
+ALTER TABLE products ADD COLUMN IF NOT EXISTS category_id_uuid UUID;
+UPDATE products p
+SET category_id_uuid = c.id_uuid
+FROM categories c
+WHERE p.category_id = c.id;
+
+ALTER TABLE products ADD COLUMN IF NOT EXISTS site_id_uuid UUID;
+UPDATE products p
+SET site_id_uuid = s.id_uuid
+FROM sites s
+WHERE p.site_id = s.id;
+
+ALTER TABLE product_prices ADD COLUMN IF NOT EXISTS product_id_uuid UUID;
+UPDATE product_prices pp
+SET product_id_uuid = p.id_uuid
+FROM products p
+WHERE pp.product_id = p.id;
+
+ALTER TABLE purchase_batches ADD COLUMN IF NOT EXISTS product_id_uuid UUID;
+UPDATE purchase_batches pb
+SET product_id_uuid = p.id_uuid
+FROM products p
+WHERE pb.product_id = p.id;
+
+ALTER TABLE purchase_batches ADD COLUMN IF NOT EXISTS site_id_uuid UUID;
+UPDATE purchase_batches pb
+SET site_id_uuid = s.id_uuid
+FROM sites s
+WHERE pb.site_id = s.id;
+
+ALTER TABLE stock_movements ADD COLUMN IF NOT EXISTS product_id_uuid UUID;
+UPDATE stock_movements sm
+SET product_id_uuid = p.id_uuid
+FROM products p
+WHERE sm.product_id = p.id;
+
+ALTER TABLE stock_movements ADD COLUMN IF NOT EXISTS site_id_uuid UUID;
+UPDATE stock_movements sm
+SET site_id_uuid = s.id_uuid
+FROM sites s
+WHERE sm.site_id = s.id;
+
+ALTER TABLE inventories ADD COLUMN IF NOT EXISTS product_id_uuid UUID;
+UPDATE inventories i
+SET product_id_uuid = p.id_uuid
+FROM products p
+WHERE i.product_id = p.id;
+
+ALTER TABLE inventories ADD COLUMN IF NOT EXISTS site_id_uuid UUID;
+UPDATE inventories i
+SET site_id_uuid = s.id_uuid
+FROM sites s
+WHERE i.site_id = s.id;
+
+ALTER TABLE product_transfers ADD COLUMN IF NOT EXISTS product_id_uuid UUID;
+UPDATE product_transfers pt
+SET product_id_uuid = p.id_uuid
+FROM products p
+WHERE pt.product_id = p.id;
+
+ALTER TABLE product_transfers ADD COLUMN IF NOT EXISTS from_site_id_uuid UUID;
+UPDATE product_transfers pt
+SET from_site_id_uuid = s.id_uuid
+FROM sites s
+WHERE pt.from_site_id = s.id;
+
+ALTER TABLE product_transfers ADD COLUMN IF NOT EXISTS to_site_id_uuid UUID;
+UPDATE product_transfers pt
+SET to_site_id_uuid = s.id_uuid
+FROM sites s
+WHERE pt.to_site_id = s.id;
+
+ALTER TABLE sales ADD COLUMN IF NOT EXISTS customer_id_uuid UUID;
+UPDATE sales s
+SET customer_id_uuid = c.id_uuid
+FROM customers c
+WHERE s.customer_id = c.id;
+
+ALTER TABLE sales ADD COLUMN IF NOT EXISTS site_id_uuid UUID;
+UPDATE sales s
+SET site_id_uuid = st.id_uuid
+FROM sites st
+WHERE s.site_id = st.id;
+
+ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS sale_id_uuid UUID;
+UPDATE sale_items si
+SET sale_id_uuid = s.id_uuid
+FROM sales s
+WHERE si.sale_id = s.id;
+
+ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS product_id_uuid UUID;
+UPDATE sale_items si
+SET product_id_uuid = p.id_uuid
+FROM products p
+WHERE si.product_id = p.id;
+
+ALTER TABLE sale_batch_allocations ADD COLUMN IF NOT EXISTS sale_item_id_uuid UUID;
+UPDATE sale_batch_allocations sba
+SET sale_item_id_uuid = si.id_uuid
+FROM sale_items si
+WHERE sba.sale_item_id = si.id;
+
+ALTER TABLE sale_batch_allocations ADD COLUMN IF NOT EXISTS batch_id_uuid UUID;
+UPDATE sale_batch_allocations sba
+SET batch_id_uuid = pb.id_uuid
+FROM purchase_batches pb
+WHERE sba.batch_id = pb.id;
+
+ALTER TABLE product_sales ADD COLUMN IF NOT EXISTS product_id_uuid UUID;
+UPDATE product_sales ps
+SET product_id_uuid = p.id_uuid
+FROM products p
+WHERE ps.product_id = p.id;
+
+ALTER TABLE product_sales ADD COLUMN IF NOT EXISTS site_id_uuid UUID;
+UPDATE product_sales ps
+SET site_id_uuid = s.id_uuid
+FROM sites s
+WHERE ps.site_id = s.id;
+
+ALTER TABLE audit_history ADD COLUMN IF NOT EXISTS entity_id_uuid UUID;
+-- Map entity_id based on entity_type (adjust if you have custom entity types)
+UPDATE audit_history ah
+SET entity_id_uuid = p.id_uuid
+FROM products p
+WHERE ah.entity_type = 'Product' AND ah.entity_id = p.id;
+
+UPDATE audit_history ah
+SET entity_id_uuid = s.id_uuid
+FROM sales s
+WHERE ah.entity_type = 'Sale' AND ah.entity_id = s.id;
+
+UPDATE audit_history ah
+SET entity_id_uuid = pb.id_uuid
+FROM purchase_batches pb
+WHERE ah.entity_type = 'PurchaseBatch' AND ah.entity_id = pb.id;
+
+UPDATE audit_history ah
+SET entity_id_uuid = u.id_uuid
+FROM app_users u
+WHERE ah.entity_type = 'User' AND ah.entity_id = u.id;
+
+ALTER TABLE audit_history ADD COLUMN IF NOT EXISTS site_id_uuid UUID;
+UPDATE audit_history ah
+SET site_id_uuid = s.id_uuid
+FROM sites s
+WHERE ah.site_id = s.id;
+
+-- --------------------------------------------------------------------------
+-- 3) DROP OLD CONSTRAINTS + COLUMNS, RENAME UUID COLUMNS
+-- --------------------------------------------------------------------------
+
+ALTER TABLE user_permissions DROP CONSTRAINT IF EXISTS user_permissions_user_id_fkey;
+ALTER TABLE user_permissions DROP CONSTRAINT IF EXISTS user_permissions_pkey;
+ALTER TABLE user_permissions DROP COLUMN user_id;
+ALTER TABLE user_permissions DROP COLUMN id;
+ALTER TABLE user_permissions RENAME COLUMN id_uuid TO id;
+ALTER TABLE user_permissions RENAME COLUMN user_id_uuid TO user_id;
+ALTER TABLE user_permissions ADD PRIMARY KEY (id);
+ALTER TABLE user_permissions ADD CONSTRAINT user_permissions_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES app_users(id) ON DELETE CASCADE;
+
+ALTER TABLE customers DROP CONSTRAINT IF EXISTS customers_site_id_fkey;
+ALTER TABLE customers DROP CONSTRAINT IF EXISTS customers_pkey;
+ALTER TABLE customers DROP COLUMN site_id;
+ALTER TABLE customers DROP COLUMN id;
+ALTER TABLE customers RENAME COLUMN id_uuid TO id;
+ALTER TABLE customers RENAME COLUMN site_id_uuid TO site_id;
+ALTER TABLE customers ADD PRIMARY KEY (id);
+ALTER TABLE customers ADD CONSTRAINT customers_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE products DROP CONSTRAINT IF EXISTS products_packaging_type_id_fkey;
+ALTER TABLE products DROP CONSTRAINT IF EXISTS products_category_id_fkey;
+ALTER TABLE products DROP CONSTRAINT IF EXISTS products_site_id_fkey;
+ALTER TABLE products DROP CONSTRAINT IF EXISTS products_pkey;
+ALTER TABLE products DROP COLUMN packaging_type_id;
+ALTER TABLE products DROP COLUMN category_id;
+ALTER TABLE products DROP COLUMN site_id;
+ALTER TABLE products DROP COLUMN id;
+ALTER TABLE products RENAME COLUMN id_uuid TO id;
+ALTER TABLE products RENAME COLUMN packaging_type_id_uuid TO packaging_type_id;
+ALTER TABLE products RENAME COLUMN category_id_uuid TO category_id;
+ALTER TABLE products RENAME COLUMN site_id_uuid TO site_id;
+ALTER TABLE products ADD PRIMARY KEY (id);
+ALTER TABLE products ADD CONSTRAINT products_packaging_type_id_fkey
+    FOREIGN KEY (packaging_type_id) REFERENCES packaging_types(id) ON DELETE SET NULL;
+ALTER TABLE products ADD CONSTRAINT products_category_id_fkey
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL;
+ALTER TABLE products ADD CONSTRAINT products_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE product_prices DROP CONSTRAINT IF EXISTS product_prices_product_id_fkey;
+ALTER TABLE product_prices DROP CONSTRAINT IF EXISTS product_prices_pkey;
+ALTER TABLE product_prices DROP COLUMN product_id;
+ALTER TABLE product_prices DROP COLUMN id;
+ALTER TABLE product_prices RENAME COLUMN id_uuid TO id;
+ALTER TABLE product_prices RENAME COLUMN product_id_uuid TO product_id;
+ALTER TABLE product_prices ADD PRIMARY KEY (id);
+ALTER TABLE product_prices ADD CONSTRAINT product_prices_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE;
+
+ALTER TABLE purchase_batches DROP CONSTRAINT IF EXISTS purchase_batches_product_id_fkey;
+ALTER TABLE purchase_batches DROP CONSTRAINT IF EXISTS purchase_batches_site_id_fkey;
+ALTER TABLE purchase_batches DROP CONSTRAINT IF EXISTS purchase_batches_pkey;
+ALTER TABLE purchase_batches DROP COLUMN product_id;
+ALTER TABLE purchase_batches DROP COLUMN site_id;
+ALTER TABLE purchase_batches DROP COLUMN id;
+ALTER TABLE purchase_batches RENAME COLUMN id_uuid TO id;
+ALTER TABLE purchase_batches RENAME COLUMN product_id_uuid TO product_id;
+ALTER TABLE purchase_batches RENAME COLUMN site_id_uuid TO site_id;
+ALTER TABLE purchase_batches ADD PRIMARY KEY (id);
+ALTER TABLE purchase_batches ADD CONSTRAINT purchase_batches_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+ALTER TABLE purchase_batches ADD CONSTRAINT purchase_batches_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE stock_movements DROP CONSTRAINT IF EXISTS stock_movements_product_id_fkey;
+ALTER TABLE stock_movements DROP CONSTRAINT IF EXISTS stock_movements_site_id_fkey;
+ALTER TABLE stock_movements DROP CONSTRAINT IF EXISTS stock_movements_pkey;
+ALTER TABLE stock_movements DROP COLUMN product_id;
+ALTER TABLE stock_movements DROP COLUMN site_id;
+ALTER TABLE stock_movements DROP COLUMN id;
+ALTER TABLE stock_movements RENAME COLUMN id_uuid TO id;
+ALTER TABLE stock_movements RENAME COLUMN product_id_uuid TO product_id;
+ALTER TABLE stock_movements RENAME COLUMN site_id_uuid TO site_id;
+ALTER TABLE stock_movements ADD PRIMARY KEY (id);
+ALTER TABLE stock_movements ADD CONSTRAINT stock_movements_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+ALTER TABLE stock_movements ADD CONSTRAINT stock_movements_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE inventories DROP CONSTRAINT IF EXISTS inventories_product_id_fkey;
+ALTER TABLE inventories DROP CONSTRAINT IF EXISTS inventories_site_id_fkey;
+ALTER TABLE inventories DROP CONSTRAINT IF EXISTS inventories_pkey;
+ALTER TABLE inventories DROP COLUMN product_id;
+ALTER TABLE inventories DROP COLUMN site_id;
+ALTER TABLE inventories DROP COLUMN id;
+ALTER TABLE inventories RENAME COLUMN id_uuid TO id;
+ALTER TABLE inventories RENAME COLUMN product_id_uuid TO product_id;
+ALTER TABLE inventories RENAME COLUMN site_id_uuid TO site_id;
+ALTER TABLE inventories ADD PRIMARY KEY (id);
+ALTER TABLE inventories ADD CONSTRAINT inventories_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+ALTER TABLE inventories ADD CONSTRAINT inventories_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE product_transfers DROP CONSTRAINT IF EXISTS product_transfers_product_id_fkey;
+ALTER TABLE product_transfers DROP CONSTRAINT IF EXISTS product_transfers_from_site_id_fkey;
+ALTER TABLE product_transfers DROP CONSTRAINT IF EXISTS product_transfers_to_site_id_fkey;
+ALTER TABLE product_transfers DROP CONSTRAINT IF EXISTS product_transfers_pkey;
+ALTER TABLE product_transfers DROP COLUMN product_id;
+ALTER TABLE product_transfers DROP COLUMN from_site_id;
+ALTER TABLE product_transfers DROP COLUMN to_site_id;
+ALTER TABLE product_transfers DROP COLUMN id;
+ALTER TABLE product_transfers RENAME COLUMN id_uuid TO id;
+ALTER TABLE product_transfers RENAME COLUMN product_id_uuid TO product_id;
+ALTER TABLE product_transfers RENAME COLUMN from_site_id_uuid TO from_site_id;
+ALTER TABLE product_transfers RENAME COLUMN to_site_id_uuid TO to_site_id;
+ALTER TABLE product_transfers ADD PRIMARY KEY (id);
+ALTER TABLE product_transfers ADD CONSTRAINT product_transfers_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+ALTER TABLE product_transfers ADD CONSTRAINT product_transfers_from_site_id_fkey
+    FOREIGN KEY (from_site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+ALTER TABLE product_transfers ADD CONSTRAINT product_transfers_to_site_id_fkey
+    FOREIGN KEY (to_site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE sales DROP CONSTRAINT IF EXISTS sales_customer_id_fkey;
+ALTER TABLE sales DROP CONSTRAINT IF EXISTS sales_site_id_fkey;
+ALTER TABLE sales DROP CONSTRAINT IF EXISTS sales_pkey;
+ALTER TABLE sales DROP COLUMN customer_id;
+ALTER TABLE sales DROP COLUMN site_id;
+ALTER TABLE sales DROP COLUMN id;
+ALTER TABLE sales RENAME COLUMN id_uuid TO id;
+ALTER TABLE sales RENAME COLUMN customer_id_uuid TO customer_id;
+ALTER TABLE sales RENAME COLUMN site_id_uuid TO site_id;
+ALTER TABLE sales ADD PRIMARY KEY (id);
+ALTER TABLE sales ADD CONSTRAINT sales_customer_id_fkey
+    FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE SET NULL;
+ALTER TABLE sales ADD CONSTRAINT sales_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE sale_items DROP CONSTRAINT IF EXISTS sale_items_sale_id_fkey;
+ALTER TABLE sale_items DROP CONSTRAINT IF EXISTS sale_items_product_id_fkey;
+ALTER TABLE sale_items DROP CONSTRAINT IF EXISTS sale_items_pkey;
+ALTER TABLE sale_items DROP COLUMN sale_id;
+ALTER TABLE sale_items DROP COLUMN product_id;
+ALTER TABLE sale_items DROP COLUMN id;
+ALTER TABLE sale_items RENAME COLUMN id_uuid TO id;
+ALTER TABLE sale_items RENAME COLUMN sale_id_uuid TO sale_id;
+ALTER TABLE sale_items RENAME COLUMN product_id_uuid TO product_id;
+ALTER TABLE sale_items ADD PRIMARY KEY (id);
+ALTER TABLE sale_items ADD CONSTRAINT sale_items_sale_id_fkey
+    FOREIGN KEY (sale_id) REFERENCES sales(id) ON DELETE CASCADE;
+ALTER TABLE sale_items ADD CONSTRAINT sale_items_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+
+ALTER TABLE sale_batch_allocations DROP CONSTRAINT IF EXISTS sale_batch_allocations_sale_item_id_fkey;
+ALTER TABLE sale_batch_allocations DROP CONSTRAINT IF EXISTS sale_batch_allocations_batch_id_fkey;
+ALTER TABLE sale_batch_allocations DROP CONSTRAINT IF EXISTS sale_batch_allocations_pkey;
+ALTER TABLE sale_batch_allocations DROP COLUMN sale_item_id;
+ALTER TABLE sale_batch_allocations DROP COLUMN batch_id;
+ALTER TABLE sale_batch_allocations DROP COLUMN id;
+ALTER TABLE sale_batch_allocations RENAME COLUMN id_uuid TO id;
+ALTER TABLE sale_batch_allocations RENAME COLUMN sale_item_id_uuid TO sale_item_id;
+ALTER TABLE sale_batch_allocations RENAME COLUMN batch_id_uuid TO batch_id;
+ALTER TABLE sale_batch_allocations ADD PRIMARY KEY (id);
+ALTER TABLE sale_batch_allocations ADD CONSTRAINT sale_batch_allocations_sale_item_id_fkey
+    FOREIGN KEY (sale_item_id) REFERENCES sale_items(id) ON DELETE CASCADE;
+ALTER TABLE sale_batch_allocations ADD CONSTRAINT sale_batch_allocations_batch_id_fkey
+    FOREIGN KEY (batch_id) REFERENCES purchase_batches(id) ON DELETE RESTRICT;
+
+ALTER TABLE product_sales DROP CONSTRAINT IF EXISTS product_sales_product_id_fkey;
+ALTER TABLE product_sales DROP CONSTRAINT IF EXISTS product_sales_site_id_fkey;
+ALTER TABLE product_sales DROP CONSTRAINT IF EXISTS product_sales_pkey;
+ALTER TABLE product_sales DROP COLUMN product_id;
+ALTER TABLE product_sales DROP COLUMN site_id;
+ALTER TABLE product_sales DROP COLUMN id;
+ALTER TABLE product_sales RENAME COLUMN id_uuid TO id;
+ALTER TABLE product_sales RENAME COLUMN product_id_uuid TO product_id;
+ALTER TABLE product_sales RENAME COLUMN site_id_uuid TO site_id;
+ALTER TABLE product_sales ADD PRIMARY KEY (id);
+ALTER TABLE product_sales ADD CONSTRAINT product_sales_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+ALTER TABLE product_sales ADD CONSTRAINT product_sales_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE audit_history DROP CONSTRAINT IF EXISTS audit_history_pkey;
+ALTER TABLE audit_history DROP COLUMN id;
+ALTER TABLE audit_history DROP COLUMN entity_id;
+ALTER TABLE audit_history DROP COLUMN site_id;
+ALTER TABLE audit_history RENAME COLUMN id_uuid TO id;
+ALTER TABLE audit_history RENAME COLUMN entity_id_uuid TO entity_id;
+ALTER TABLE audit_history RENAME COLUMN site_id_uuid TO site_id;
+ALTER TABLE audit_history ADD PRIMARY KEY (id);
+ALTER TABLE audit_history ADD CONSTRAINT audit_history_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE SET NULL;
+
+ALTER TABLE sites DROP CONSTRAINT IF EXISTS sites_pkey;
+ALTER TABLE sites DROP COLUMN id;
+ALTER TABLE sites RENAME COLUMN id_uuid TO id;
+ALTER TABLE sites ADD PRIMARY KEY (id);
+
+ALTER TABLE categories DROP CONSTRAINT IF EXISTS categories_pkey;
+ALTER TABLE categories DROP COLUMN id;
+ALTER TABLE categories RENAME COLUMN id_uuid TO id;
+ALTER TABLE categories ADD PRIMARY KEY (id);
+
+ALTER TABLE packaging_types DROP CONSTRAINT IF EXISTS packaging_types_pkey;
+ALTER TABLE packaging_types DROP COLUMN id;
+ALTER TABLE packaging_types RENAME COLUMN id_uuid TO id;
+ALTER TABLE packaging_types ADD PRIMARY KEY (id);
+
+ALTER TABLE app_users DROP CONSTRAINT IF EXISTS app_users_pkey;
+ALTER TABLE app_users DROP COLUMN id;
+ALTER TABLE app_users RENAME COLUMN id_uuid TO id;
+ALTER TABLE app_users ADD PRIMARY KEY (id);
+
+-- --------------------------------------------------------------------------
+-- 4) DEFAULTS FOR UUID PKs
+-- --------------------------------------------------------------------------
+
+ALTER TABLE sites ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE categories ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE packaging_types ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE app_users ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE user_permissions ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE customers ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE products ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE product_prices ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE purchase_batches ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE stock_movements ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE inventories ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE product_transfers ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE sales ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE sale_items ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE sale_batch_allocations ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE product_sales ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE audit_history ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+
+COMMIT;
+
+-- ============================================================================
+-- END OF UUID MIGRATION
+-- ============================================================================

--- a/supabase-uuid-migration.sql
+++ b/supabase-uuid-migration.sql
@@ -8,6 +8,35 @@ BEGIN;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- --------------------------------------------------------------------------
+-- 0) DROP FOREIGN KEYS THAT DEPEND ON CURRENT PKs
+-- --------------------------------------------------------------------------
+
+ALTER TABLE IF EXISTS user_permissions DROP CONSTRAINT IF EXISTS user_permissions_user_id_fkey;
+ALTER TABLE IF EXISTS customers DROP CONSTRAINT IF EXISTS customers_site_id_fkey;
+ALTER TABLE IF EXISTS products DROP CONSTRAINT IF EXISTS products_packaging_type_id_fkey;
+ALTER TABLE IF EXISTS products DROP CONSTRAINT IF EXISTS products_category_id_fkey;
+ALTER TABLE IF EXISTS products DROP CONSTRAINT IF EXISTS products_site_id_fkey;
+ALTER TABLE IF EXISTS product_prices DROP CONSTRAINT IF EXISTS product_prices_product_id_fkey;
+ALTER TABLE IF EXISTS purchase_batches DROP CONSTRAINT IF EXISTS purchase_batches_product_id_fkey;
+ALTER TABLE IF EXISTS purchase_batches DROP CONSTRAINT IF EXISTS purchase_batches_site_id_fkey;
+ALTER TABLE IF EXISTS stock_movements DROP CONSTRAINT IF EXISTS stock_movements_product_id_fkey;
+ALTER TABLE IF EXISTS stock_movements DROP CONSTRAINT IF EXISTS stock_movements_site_id_fkey;
+ALTER TABLE IF EXISTS inventories DROP CONSTRAINT IF EXISTS inventories_product_id_fkey;
+ALTER TABLE IF EXISTS inventories DROP CONSTRAINT IF EXISTS inventories_site_id_fkey;
+ALTER TABLE IF EXISTS product_transfers DROP CONSTRAINT IF EXISTS product_transfers_product_id_fkey;
+ALTER TABLE IF EXISTS product_transfers DROP CONSTRAINT IF EXISTS product_transfers_from_site_id_fkey;
+ALTER TABLE IF EXISTS product_transfers DROP CONSTRAINT IF EXISTS product_transfers_to_site_id_fkey;
+ALTER TABLE IF EXISTS sales DROP CONSTRAINT IF EXISTS sales_customer_id_fkey;
+ALTER TABLE IF EXISTS sales DROP CONSTRAINT IF EXISTS sales_site_id_fkey;
+ALTER TABLE IF EXISTS sale_items DROP CONSTRAINT IF EXISTS sale_items_sale_id_fkey;
+ALTER TABLE IF EXISTS sale_items DROP CONSTRAINT IF EXISTS sale_items_product_id_fkey;
+ALTER TABLE IF EXISTS sale_batch_allocations DROP CONSTRAINT IF EXISTS sale_batch_allocations_sale_item_id_fkey;
+ALTER TABLE IF EXISTS sale_batch_allocations DROP CONSTRAINT IF EXISTS sale_batch_allocations_batch_id_fkey;
+ALTER TABLE IF EXISTS product_sales DROP CONSTRAINT IF EXISTS product_sales_product_id_fkey;
+ALTER TABLE IF EXISTS product_sales DROP CONSTRAINT IF EXISTS product_sales_site_id_fkey;
+ALTER TABLE IF EXISTS audit_history DROP CONSTRAINT IF EXISTS audit_history_site_id_fkey;
+
+-- --------------------------------------------------------------------------
 -- 1) PRIMARY TABLES: add UUID columns and backfill
 -- --------------------------------------------------------------------------
 

--- a/supabase-uuid-migration.sql
+++ b/supabase-uuid-migration.sql
@@ -243,8 +243,6 @@ ALTER TABLE user_permissions DROP COLUMN id;
 ALTER TABLE user_permissions RENAME COLUMN id_uuid TO id;
 ALTER TABLE user_permissions RENAME COLUMN user_id_uuid TO user_id;
 ALTER TABLE user_permissions ADD PRIMARY KEY (id);
-ALTER TABLE user_permissions ADD CONSTRAINT user_permissions_user_id_fkey
-    FOREIGN KEY (user_id) REFERENCES app_users(id) ON DELETE CASCADE;
 
 ALTER TABLE customers DROP CONSTRAINT IF EXISTS customers_site_id_fkey;
 ALTER TABLE customers DROP CONSTRAINT IF EXISTS customers_pkey;
@@ -253,8 +251,6 @@ ALTER TABLE customers DROP COLUMN id;
 ALTER TABLE customers RENAME COLUMN id_uuid TO id;
 ALTER TABLE customers RENAME COLUMN site_id_uuid TO site_id;
 ALTER TABLE customers ADD PRIMARY KEY (id);
-ALTER TABLE customers ADD CONSTRAINT customers_site_id_fkey
-    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
 
 ALTER TABLE products DROP CONSTRAINT IF EXISTS products_packaging_type_id_fkey;
 ALTER TABLE products DROP CONSTRAINT IF EXISTS products_category_id_fkey;
@@ -269,12 +265,6 @@ ALTER TABLE products RENAME COLUMN packaging_type_id_uuid TO packaging_type_id;
 ALTER TABLE products RENAME COLUMN category_id_uuid TO category_id;
 ALTER TABLE products RENAME COLUMN site_id_uuid TO site_id;
 ALTER TABLE products ADD PRIMARY KEY (id);
-ALTER TABLE products ADD CONSTRAINT products_packaging_type_id_fkey
-    FOREIGN KEY (packaging_type_id) REFERENCES packaging_types(id) ON DELETE SET NULL;
-ALTER TABLE products ADD CONSTRAINT products_category_id_fkey
-    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL;
-ALTER TABLE products ADD CONSTRAINT products_site_id_fkey
-    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
 
 ALTER TABLE product_prices DROP CONSTRAINT IF EXISTS product_prices_product_id_fkey;
 ALTER TABLE product_prices DROP CONSTRAINT IF EXISTS product_prices_pkey;
@@ -283,8 +273,6 @@ ALTER TABLE product_prices DROP COLUMN id;
 ALTER TABLE product_prices RENAME COLUMN id_uuid TO id;
 ALTER TABLE product_prices RENAME COLUMN product_id_uuid TO product_id;
 ALTER TABLE product_prices ADD PRIMARY KEY (id);
-ALTER TABLE product_prices ADD CONSTRAINT product_prices_product_id_fkey
-    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE;
 
 ALTER TABLE purchase_batches DROP CONSTRAINT IF EXISTS purchase_batches_product_id_fkey;
 ALTER TABLE purchase_batches DROP CONSTRAINT IF EXISTS purchase_batches_site_id_fkey;
@@ -296,10 +284,6 @@ ALTER TABLE purchase_batches RENAME COLUMN id_uuid TO id;
 ALTER TABLE purchase_batches RENAME COLUMN product_id_uuid TO product_id;
 ALTER TABLE purchase_batches RENAME COLUMN site_id_uuid TO site_id;
 ALTER TABLE purchase_batches ADD PRIMARY KEY (id);
-ALTER TABLE purchase_batches ADD CONSTRAINT purchase_batches_product_id_fkey
-    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
-ALTER TABLE purchase_batches ADD CONSTRAINT purchase_batches_site_id_fkey
-    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
 
 ALTER TABLE stock_movements DROP CONSTRAINT IF EXISTS stock_movements_product_id_fkey;
 ALTER TABLE stock_movements DROP CONSTRAINT IF EXISTS stock_movements_site_id_fkey;
@@ -311,10 +295,6 @@ ALTER TABLE stock_movements RENAME COLUMN id_uuid TO id;
 ALTER TABLE stock_movements RENAME COLUMN product_id_uuid TO product_id;
 ALTER TABLE stock_movements RENAME COLUMN site_id_uuid TO site_id;
 ALTER TABLE stock_movements ADD PRIMARY KEY (id);
-ALTER TABLE stock_movements ADD CONSTRAINT stock_movements_product_id_fkey
-    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
-ALTER TABLE stock_movements ADD CONSTRAINT stock_movements_site_id_fkey
-    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
 
 ALTER TABLE inventories DROP CONSTRAINT IF EXISTS inventories_product_id_fkey;
 ALTER TABLE inventories DROP CONSTRAINT IF EXISTS inventories_site_id_fkey;
@@ -326,10 +306,6 @@ ALTER TABLE inventories RENAME COLUMN id_uuid TO id;
 ALTER TABLE inventories RENAME COLUMN product_id_uuid TO product_id;
 ALTER TABLE inventories RENAME COLUMN site_id_uuid TO site_id;
 ALTER TABLE inventories ADD PRIMARY KEY (id);
-ALTER TABLE inventories ADD CONSTRAINT inventories_product_id_fkey
-    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
-ALTER TABLE inventories ADD CONSTRAINT inventories_site_id_fkey
-    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
 
 ALTER TABLE product_transfers DROP CONSTRAINT IF EXISTS product_transfers_product_id_fkey;
 ALTER TABLE product_transfers DROP CONSTRAINT IF EXISTS product_transfers_from_site_id_fkey;
@@ -344,12 +320,6 @@ ALTER TABLE product_transfers RENAME COLUMN product_id_uuid TO product_id;
 ALTER TABLE product_transfers RENAME COLUMN from_site_id_uuid TO from_site_id;
 ALTER TABLE product_transfers RENAME COLUMN to_site_id_uuid TO to_site_id;
 ALTER TABLE product_transfers ADD PRIMARY KEY (id);
-ALTER TABLE product_transfers ADD CONSTRAINT product_transfers_product_id_fkey
-    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
-ALTER TABLE product_transfers ADD CONSTRAINT product_transfers_from_site_id_fkey
-    FOREIGN KEY (from_site_id) REFERENCES sites(id) ON DELETE RESTRICT;
-ALTER TABLE product_transfers ADD CONSTRAINT product_transfers_to_site_id_fkey
-    FOREIGN KEY (to_site_id) REFERENCES sites(id) ON DELETE RESTRICT;
 
 ALTER TABLE sales DROP CONSTRAINT IF EXISTS sales_customer_id_fkey;
 ALTER TABLE sales DROP CONSTRAINT IF EXISTS sales_site_id_fkey;
@@ -361,10 +331,6 @@ ALTER TABLE sales RENAME COLUMN id_uuid TO id;
 ALTER TABLE sales RENAME COLUMN customer_id_uuid TO customer_id;
 ALTER TABLE sales RENAME COLUMN site_id_uuid TO site_id;
 ALTER TABLE sales ADD PRIMARY KEY (id);
-ALTER TABLE sales ADD CONSTRAINT sales_customer_id_fkey
-    FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE SET NULL;
-ALTER TABLE sales ADD CONSTRAINT sales_site_id_fkey
-    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
 
 ALTER TABLE sale_items DROP CONSTRAINT IF EXISTS sale_items_sale_id_fkey;
 ALTER TABLE sale_items DROP CONSTRAINT IF EXISTS sale_items_product_id_fkey;
@@ -376,10 +342,6 @@ ALTER TABLE sale_items RENAME COLUMN id_uuid TO id;
 ALTER TABLE sale_items RENAME COLUMN sale_id_uuid TO sale_id;
 ALTER TABLE sale_items RENAME COLUMN product_id_uuid TO product_id;
 ALTER TABLE sale_items ADD PRIMARY KEY (id);
-ALTER TABLE sale_items ADD CONSTRAINT sale_items_sale_id_fkey
-    FOREIGN KEY (sale_id) REFERENCES sales(id) ON DELETE CASCADE;
-ALTER TABLE sale_items ADD CONSTRAINT sale_items_product_id_fkey
-    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
 
 ALTER TABLE sale_batch_allocations DROP CONSTRAINT IF EXISTS sale_batch_allocations_sale_item_id_fkey;
 ALTER TABLE sale_batch_allocations DROP CONSTRAINT IF EXISTS sale_batch_allocations_batch_id_fkey;
@@ -391,10 +353,6 @@ ALTER TABLE sale_batch_allocations RENAME COLUMN id_uuid TO id;
 ALTER TABLE sale_batch_allocations RENAME COLUMN sale_item_id_uuid TO sale_item_id;
 ALTER TABLE sale_batch_allocations RENAME COLUMN batch_id_uuid TO batch_id;
 ALTER TABLE sale_batch_allocations ADD PRIMARY KEY (id);
-ALTER TABLE sale_batch_allocations ADD CONSTRAINT sale_batch_allocations_sale_item_id_fkey
-    FOREIGN KEY (sale_item_id) REFERENCES sale_items(id) ON DELETE CASCADE;
-ALTER TABLE sale_batch_allocations ADD CONSTRAINT sale_batch_allocations_batch_id_fkey
-    FOREIGN KEY (batch_id) REFERENCES purchase_batches(id) ON DELETE RESTRICT;
 
 ALTER TABLE product_sales DROP CONSTRAINT IF EXISTS product_sales_product_id_fkey;
 ALTER TABLE product_sales DROP CONSTRAINT IF EXISTS product_sales_site_id_fkey;
@@ -406,10 +364,6 @@ ALTER TABLE product_sales RENAME COLUMN id_uuid TO id;
 ALTER TABLE product_sales RENAME COLUMN product_id_uuid TO product_id;
 ALTER TABLE product_sales RENAME COLUMN site_id_uuid TO site_id;
 ALTER TABLE product_sales ADD PRIMARY KEY (id);
-ALTER TABLE product_sales ADD CONSTRAINT product_sales_product_id_fkey
-    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
-ALTER TABLE product_sales ADD CONSTRAINT product_sales_site_id_fkey
-    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
 
 ALTER TABLE audit_history DROP CONSTRAINT IF EXISTS audit_history_pkey;
 ALTER TABLE audit_history DROP COLUMN id;
@@ -419,8 +373,6 @@ ALTER TABLE audit_history RENAME COLUMN id_uuid TO id;
 ALTER TABLE audit_history RENAME COLUMN entity_id_uuid TO entity_id;
 ALTER TABLE audit_history RENAME COLUMN site_id_uuid TO site_id;
 ALTER TABLE audit_history ADD PRIMARY KEY (id);
-ALTER TABLE audit_history ADD CONSTRAINT audit_history_site_id_fkey
-    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE SET NULL;
 
 ALTER TABLE sites DROP CONSTRAINT IF EXISTS sites_pkey;
 ALTER TABLE sites DROP COLUMN id;
@@ -441,6 +393,71 @@ ALTER TABLE app_users DROP CONSTRAINT IF EXISTS app_users_pkey;
 ALTER TABLE app_users DROP COLUMN id;
 ALTER TABLE app_users RENAME COLUMN id_uuid TO id;
 ALTER TABLE app_users ADD PRIMARY KEY (id);
+
+-- --------------------------------------------------------------------------
+-- 3b) RECREATE FOREIGN KEYS AFTER UUID SWAP
+-- --------------------------------------------------------------------------
+
+ALTER TABLE user_permissions ADD CONSTRAINT user_permissions_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES app_users(id) ON DELETE CASCADE;
+
+ALTER TABLE customers ADD CONSTRAINT customers_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE products ADD CONSTRAINT products_packaging_type_id_fkey
+    FOREIGN KEY (packaging_type_id) REFERENCES packaging_types(id) ON DELETE SET NULL;
+ALTER TABLE products ADD CONSTRAINT products_category_id_fkey
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL;
+ALTER TABLE products ADD CONSTRAINT products_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE product_prices ADD CONSTRAINT product_prices_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE;
+
+ALTER TABLE purchase_batches ADD CONSTRAINT purchase_batches_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+ALTER TABLE purchase_batches ADD CONSTRAINT purchase_batches_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE stock_movements ADD CONSTRAINT stock_movements_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+ALTER TABLE stock_movements ADD CONSTRAINT stock_movements_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE inventories ADD CONSTRAINT inventories_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+ALTER TABLE inventories ADD CONSTRAINT inventories_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE product_transfers ADD CONSTRAINT product_transfers_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+ALTER TABLE product_transfers ADD CONSTRAINT product_transfers_from_site_id_fkey
+    FOREIGN KEY (from_site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+ALTER TABLE product_transfers ADD CONSTRAINT product_transfers_to_site_id_fkey
+    FOREIGN KEY (to_site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE sales ADD CONSTRAINT sales_customer_id_fkey
+    FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE SET NULL;
+ALTER TABLE sales ADD CONSTRAINT sales_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE sale_items ADD CONSTRAINT sale_items_sale_id_fkey
+    FOREIGN KEY (sale_id) REFERENCES sales(id) ON DELETE CASCADE;
+ALTER TABLE sale_items ADD CONSTRAINT sale_items_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+
+ALTER TABLE sale_batch_allocations ADD CONSTRAINT sale_batch_allocations_sale_item_id_fkey
+    FOREIGN KEY (sale_item_id) REFERENCES sale_items(id) ON DELETE CASCADE;
+ALTER TABLE sale_batch_allocations ADD CONSTRAINT sale_batch_allocations_batch_id_fkey
+    FOREIGN KEY (batch_id) REFERENCES purchase_batches(id) ON DELETE RESTRICT;
+
+ALTER TABLE product_sales ADD CONSTRAINT product_sales_product_id_fkey
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT;
+ALTER TABLE product_sales ADD CONSTRAINT product_sales_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE RESTRICT;
+
+ALTER TABLE audit_history ADD CONSTRAINT audit_history_site_id_fkey
+    FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE SET NULL;
 
 -- --------------------------------------------------------------------------
 -- 4) DEFAULTS FOR UUID PKs


### PR DESCRIPTION
### Motivation
- Replace numeric (Long/BIGINT/BIGSERIAL) IDs with UUIDs everywhere to support stable globally-unique identifiers across the Android client and Supabase backend.  
- Ensure entities, APIs and UI flows can use UUID strings end-to-end without losing referential integrity.  
- Provide a database migration path for existing Supabase data to convert integer PKs/FKs to UUIDs.  
- Avoid mixing ID types and simplify cross-system synchronization and future multi-instance deployments.  

### Description
- Converted Room entities to use String IDs with client-side UUID generation (added `UUID.randomUUID()` usages) and bumped Room DB version to `10`.  
- Updated DAOs, repositories, DTOs and Supabase repositories to accept and return `String` IDs (UUIDs) and adjusted usages in ViewModels and UI activities to pass/expect string IDs.  
- Updated shared helpers: `PrefsHelper` now stores `activeSiteId` as `String`, `AuthManager` persists `user_id` as `String`, and `PermissionManager`/`AuditLogger` now use string IDs for lookups and logs.  
- Revised Supabase artifacts: `supabase-schema.sql` and `supabase-rls-policies.sql` to use UUID PKs/FKs and updated RLS examples to parse JWT claim `site_id` as `::uuid`, and added a migration script `supabase-uuid-migration.sql` to backfill and rename UUID columns while re-wiring FKs.  

### Testing
- No automated tests were run as part of this change.  
- The migration work includes a SQL script `supabase-uuid-migration.sql` intended to be executed on the Supabase instance to backfill UUIDs and swap PK/FK columns.  
- Code compiles and runtime validation is recommended in a local/dev environment before deploying migration to production.  
- Manual/manual-integration verification is recommended for flows that rely on intent extras and `PrefsHelper` persisted site/user IDs (e.g. site selection, create/edit product, sales/purchase flows).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694904c978a08326ad52e6836e36524f)