### PR TITLE
Fix created_by attribution across app and add Supabase defaults + migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# medistock-app
+# Medistock App
+
+Application Android de gestion de stock pharmaceutique (sites, produits, achats, ventes, transferts, inventaires) avec synchronisation Supabase.
+
+## Fonctionnalités principales
+
+- Gestion multi-sites (création, sélection, transferts).
+- Gestion des catégories, conditionnements, produits et prix.
+- Achats (lots FIFO), mouvements de stock, inventaires.
+- Ventes avec allocations FIFO et clients.
+- Gestion utilisateurs et permissions.
+- Synchronisation Supabase (schéma + politiques RLS fournis).
+
+## Prérequis
+
+- Android Studio (ou Gradle CLI)
+- JDK 17
+- Accès Supabase si vous activez la synchronisation (URL + clé API)
+
+## Configuration du projet
+
+1. Cloner le dépôt.
+2. Ouvrir le projet dans Android Studio.
+3. (Optionnel) Configurer Supabase via l’écran **Admin > Supabase** dans l’app :
+   - URL Supabase
+   - Clé API
+
+## Lancer l’application
+
+- Depuis Android Studio : **Run** sur un appareil/émulateur.
+- En ligne de commande :
+  ```bash
+  ./gradlew assembleDebug
+  ```
+
+L’APK debug se trouve dans `app/build/outputs/apk/debug/`.
+
+## Scripts Supabase
+
+Les scripts SQL sont disponibles à la racine :
+
+- `supabase-schema.sql` : schéma complet (tables, triggers).
+- `supabase-rls-policies.sql` : politiques RLS.
+- `supabase-uuid-migration.sql` : migration UUID.
+- `supabase-created-updated-by-migration.sql` : backfill et defaults `created_by`/`updated_by`.
+
+## Structure du projet
+
+- `app/src/main/java/com/medistock` : code Android (UI, data, sync).
+- `app/src/main/res` : ressources (layouts, strings, styles).
+- `supabase-*.sql` : scripts SQL de base de données.
+
+## Notes
+
+- Les champs `created_by` / `updated_by` sont remplis automatiquement par l’app et sécurisés côté base via defaults + triggers.

--- a/app/src/main/java/com/medistock/ui/movement/StockMovementActivity.kt
+++ b/app/src/main/java/com/medistock/ui/movement/StockMovementActivity.kt
@@ -9,12 +9,14 @@ import androidx.room.Room
 import com.medistock.R
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.*
+import com.medistock.util.AuthManager
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class StockMovementActivity : AppCompatActivity() {
 
     private lateinit var db: AppDatabase
+    private lateinit var authManager: AuthManager
     private var products: List<Product> = emptyList()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -23,6 +25,7 @@ class StockMovementActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         db = AppDatabase.getInstance(this)
+        authManager = AuthManager.getInstance(this)
 
         val productSpinner = findViewById<Spinner>(R.id.spinnerProduct)
         val typeSpinner = findViewById<Spinner>(R.id.spinnerType)
@@ -53,6 +56,7 @@ class StockMovementActivity : AppCompatActivity() {
                     if (latestPrice != null) {
                         val siteId = com.medistock.util.PrefsHelper.getActiveSiteId(this@StockMovementActivity)
                         if (!siteId.isNullOrBlank()) {
+                            val currentUser = authManager.getUsername().ifBlank { "system" }
                             db.stockMovementDao().insert(
                                 StockMovement(
                                     productId = product.id,
@@ -61,7 +65,8 @@ class StockMovementActivity : AppCompatActivity() {
                                     date = System.currentTimeMillis(),
                                     purchasePriceAtMovement = latestPrice.purchasePrice,
                                     sellingPriceAtMovement = latestPrice.sellingPrice,
-                                    siteId = siteId
+                                    siteId = siteId,
+                                    createdBy = currentUser
                                 )
                             )
                             finish()

--- a/app/src/main/java/com/medistock/ui/packaging/PackagingTypeAddEditActivity.kt
+++ b/app/src/main/java/com/medistock/ui/packaging/PackagingTypeAddEditActivity.kt
@@ -9,10 +9,12 @@ import androidx.lifecycle.ViewModelProvider
 import com.medistock.R
 import com.medistock.data.entities.PackagingType
 import com.medistock.ui.viewmodel.PackagingTypeViewModel
+import com.medistock.util.AuthManager
 
 class PackagingTypeAddEditActivity : AppCompatActivity() {
 
     private lateinit var viewModel: PackagingTypeViewModel
+    private lateinit var authManager: AuthManager
     private var packagingTypeId: String? = null
     private var existingPackagingType: PackagingType? = null
 
@@ -39,6 +41,7 @@ class PackagingTypeAddEditActivity : AppCompatActivity() {
         }
 
         viewModel = ViewModelProvider(this)[PackagingTypeViewModel::class.java]
+        authManager = AuthManager.getInstance(this)
 
         initViews()
         setupListeners()
@@ -142,6 +145,9 @@ class PackagingTypeAddEditActivity : AppCompatActivity() {
         }
 
         val isActive = checkboxActive.isChecked
+        val currentUser = authManager.getUsername().ifBlank { "system" }
+        val createdAt = existingPackagingType?.createdAt ?: System.currentTimeMillis()
+        val createdBy = existingPackagingType?.createdBy?.ifBlank { currentUser } ?: currentUser
 
         val packagingType = if (packagingTypeId == null) {
             PackagingType(
@@ -151,10 +157,10 @@ class PackagingTypeAddEditActivity : AppCompatActivity() {
                 defaultConversionFactor = conversionFactor,
                 isActive = isActive,
                 displayOrder = existingPackagingType?.displayOrder ?: 0,
-                createdAt = existingPackagingType?.createdAt ?: System.currentTimeMillis(),
+                createdAt = createdAt,
                 updatedAt = System.currentTimeMillis(),
-                createdBy = existingPackagingType?.createdBy,
-                updatedBy = null // TODO: Add current user
+                createdBy = createdBy,
+                updatedBy = currentUser
             )
         } else {
             PackagingType(
@@ -165,10 +171,10 @@ class PackagingTypeAddEditActivity : AppCompatActivity() {
                 defaultConversionFactor = conversionFactor,
                 isActive = isActive,
                 displayOrder = existingPackagingType?.displayOrder ?: 0,
-                createdAt = existingPackagingType?.createdAt ?: System.currentTimeMillis(),
+                createdAt = createdAt,
                 updatedAt = System.currentTimeMillis(),
-                createdBy = existingPackagingType?.createdBy,
-                updatedBy = null // TODO: Add current user
+                createdBy = createdBy,
+                updatedBy = currentUser
             )
         }
 

--- a/app/src/main/java/com/medistock/ui/product/ProductAddActivity.kt
+++ b/app/src/main/java/com/medistock/ui/product/ProductAddActivity.kt
@@ -12,6 +12,7 @@ import com.medistock.R
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.Category
 import com.medistock.data.entities.Product
+import com.medistock.util.AuthManager
 import com.medistock.util.PrefsHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -21,6 +22,7 @@ import kotlinx.coroutines.withContext
 class ProductAddActivity : AppCompatActivity() {
 
     private lateinit var db: AppDatabase
+    private lateinit var authManager: AuthManager
     private lateinit var editName: EditText
     private lateinit var spinnerCategory: Spinner
     private lateinit var spinnerUnit: Spinner
@@ -45,6 +47,7 @@ class ProductAddActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         db = AppDatabase.getInstance(this)
+        authManager = AuthManager.getInstance(this)
 
         editName = findViewById(R.id.editProductName)
         spinnerCategory = findViewById(R.id.spinnerCategory)
@@ -190,6 +193,7 @@ class ProductAddActivity : AppCompatActivity() {
             }
 
             // Create product
+            val currentUser = authManager.getUsername().ifBlank { "system" }
             val product = Product(
                 name = productName,
                 categoryId = selectedCategoryId,
@@ -197,7 +201,9 @@ class ProductAddActivity : AppCompatActivity() {
                 marginType = selectedMarginType,
                 marginValue = enteredMarginValue,
                 unitVolume = enteredUnitVolume,
-                siteId = currentSiteId!!
+                siteId = currentSiteId!!,
+                createdBy = currentUser,
+                updatedBy = currentUser
             )
 
             lifecycleScope.launch {

--- a/supabase-created-updated-by-migration.sql
+++ b/supabase-created-updated-by-migration.sql
@@ -1,0 +1,173 @@
+-- ============================================================================
+-- Migration: set default created_by/updated_by to 'system' and backfill data
+-- ============================================================================
+
+BEGIN;
+
+-- Backfill existing records
+UPDATE sites SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+UPDATE sites SET updated_by = 'system' WHERE updated_by IS NULL OR updated_by = '';
+
+UPDATE categories SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+UPDATE categories SET updated_by = 'system' WHERE updated_by IS NULL OR updated_by = '';
+
+UPDATE packaging_types SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+UPDATE packaging_types SET updated_by = 'system' WHERE updated_by IS NULL OR updated_by = '';
+
+UPDATE app_users SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+UPDATE app_users SET updated_by = 'system' WHERE updated_by IS NULL OR updated_by = '';
+
+UPDATE user_permissions SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+UPDATE user_permissions SET updated_by = 'system' WHERE updated_by IS NULL OR updated_by = '';
+
+UPDATE customers SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+
+UPDATE products SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+UPDATE products SET updated_by = 'system' WHERE updated_by IS NULL OR updated_by = '';
+
+UPDATE product_prices SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+UPDATE product_prices SET updated_by = 'system' WHERE updated_by IS NULL OR updated_by = '';
+
+UPDATE purchase_batches SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+UPDATE purchase_batches SET updated_by = 'system' WHERE updated_by IS NULL OR updated_by = '';
+
+UPDATE stock_movements SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+
+UPDATE inventories SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+
+UPDATE product_transfers SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+UPDATE product_transfers SET updated_by = 'system' WHERE updated_by IS NULL OR updated_by = '';
+
+UPDATE sales SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+
+UPDATE product_sales SET created_by = 'system' WHERE created_by IS NULL OR created_by = '';
+
+-- Set defaults
+ALTER TABLE sites ALTER COLUMN created_by SET DEFAULT 'system';
+ALTER TABLE sites ALTER COLUMN updated_by SET DEFAULT 'system';
+
+ALTER TABLE categories ALTER COLUMN created_by SET DEFAULT 'system';
+ALTER TABLE categories ALTER COLUMN updated_by SET DEFAULT 'system';
+
+ALTER TABLE packaging_types ALTER COLUMN created_by SET DEFAULT 'system';
+ALTER TABLE packaging_types ALTER COLUMN updated_by SET DEFAULT 'system';
+ALTER TABLE packaging_types ALTER COLUMN created_by SET NOT NULL;
+ALTER TABLE packaging_types ALTER COLUMN updated_by SET NOT NULL;
+
+ALTER TABLE app_users ALTER COLUMN created_by SET DEFAULT 'system';
+ALTER TABLE app_users ALTER COLUMN updated_by SET DEFAULT 'system';
+
+ALTER TABLE user_permissions ALTER COLUMN created_by SET DEFAULT 'system';
+ALTER TABLE user_permissions ALTER COLUMN updated_by SET DEFAULT 'system';
+
+ALTER TABLE customers ALTER COLUMN created_by SET DEFAULT 'system';
+
+ALTER TABLE products ALTER COLUMN created_by SET DEFAULT 'system';
+ALTER TABLE products ALTER COLUMN updated_by SET DEFAULT 'system';
+
+ALTER TABLE product_prices ALTER COLUMN created_by SET DEFAULT 'system';
+ALTER TABLE product_prices ALTER COLUMN updated_by SET DEFAULT 'system';
+
+ALTER TABLE purchase_batches ALTER COLUMN created_by SET DEFAULT 'system';
+ALTER TABLE purchase_batches ALTER COLUMN updated_by SET DEFAULT 'system';
+
+ALTER TABLE stock_movements ALTER COLUMN created_by SET DEFAULT 'system';
+
+ALTER TABLE inventories ALTER COLUMN created_by SET DEFAULT 'system';
+
+ALTER TABLE product_transfers ALTER COLUMN created_by SET DEFAULT 'system';
+ALTER TABLE product_transfers ALTER COLUMN updated_by SET DEFAULT 'system';
+
+ALTER TABLE sales ALTER COLUMN created_by SET DEFAULT 'system';
+
+ALTER TABLE product_sales ALTER COLUMN created_by SET DEFAULT 'system';
+
+-- Functions and triggers
+CREATE OR REPLACE FUNCTION set_audit_user_defaults()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.created_by IS NULL OR NEW.created_by = '' THEN
+        NEW.created_by = 'system';
+    END IF;
+
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.updated_by IS NULL OR NEW.updated_by = '' THEN
+            NEW.updated_by = NEW.created_by;
+        END IF;
+    ELSE
+        IF NEW.updated_by IS NULL OR NEW.updated_by = '' THEN
+            NEW.updated_by = 'system';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE OR REPLACE FUNCTION set_created_by_default()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.created_by IS NULL OR NEW.created_by = '' THEN
+        NEW.created_by = 'system';
+    END IF;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+DROP TRIGGER IF EXISTS set_sites_audit_defaults ON sites;
+CREATE TRIGGER set_sites_audit_defaults BEFORE INSERT OR UPDATE ON sites
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+DROP TRIGGER IF EXISTS set_categories_audit_defaults ON categories;
+CREATE TRIGGER set_categories_audit_defaults BEFORE INSERT OR UPDATE ON categories
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+DROP TRIGGER IF EXISTS set_packaging_types_audit_defaults ON packaging_types;
+CREATE TRIGGER set_packaging_types_audit_defaults BEFORE INSERT OR UPDATE ON packaging_types
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+DROP TRIGGER IF EXISTS set_app_users_audit_defaults ON app_users;
+CREATE TRIGGER set_app_users_audit_defaults BEFORE INSERT OR UPDATE ON app_users
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+DROP TRIGGER IF EXISTS set_user_permissions_audit_defaults ON user_permissions;
+CREATE TRIGGER set_user_permissions_audit_defaults BEFORE INSERT OR UPDATE ON user_permissions
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+DROP TRIGGER IF EXISTS set_products_audit_defaults ON products;
+CREATE TRIGGER set_products_audit_defaults BEFORE INSERT OR UPDATE ON products
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+DROP TRIGGER IF EXISTS set_product_prices_audit_defaults ON product_prices;
+CREATE TRIGGER set_product_prices_audit_defaults BEFORE INSERT OR UPDATE ON product_prices
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+DROP TRIGGER IF EXISTS set_purchase_batches_audit_defaults ON purchase_batches;
+CREATE TRIGGER set_purchase_batches_audit_defaults BEFORE INSERT OR UPDATE ON purchase_batches
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+DROP TRIGGER IF EXISTS set_product_transfers_audit_defaults ON product_transfers;
+CREATE TRIGGER set_product_transfers_audit_defaults BEFORE INSERT OR UPDATE ON product_transfers
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+DROP TRIGGER IF EXISTS set_customers_created_by ON customers;
+CREATE TRIGGER set_customers_created_by BEFORE INSERT ON customers
+    FOR EACH ROW EXECUTE FUNCTION set_created_by_default();
+
+DROP TRIGGER IF EXISTS set_stock_movements_created_by ON stock_movements;
+CREATE TRIGGER set_stock_movements_created_by BEFORE INSERT ON stock_movements
+    FOR EACH ROW EXECUTE FUNCTION set_created_by_default();
+
+DROP TRIGGER IF EXISTS set_inventories_created_by ON inventories;
+CREATE TRIGGER set_inventories_created_by BEFORE INSERT ON inventories
+    FOR EACH ROW EXECUTE FUNCTION set_created_by_default();
+
+DROP TRIGGER IF EXISTS set_sales_created_by ON sales;
+CREATE TRIGGER set_sales_created_by BEFORE INSERT ON sales
+    FOR EACH ROW EXECUTE FUNCTION set_created_by_default();
+
+DROP TRIGGER IF EXISTS set_product_sales_created_by ON product_sales;
+CREATE TRIGGER set_product_sales_created_by BEFORE INSERT ON product_sales
+    FOR EACH ROW EXECUTE FUNCTION set_created_by_default();
+
+COMMIT;

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -16,8 +16,8 @@ CREATE TABLE sites (
     name TEXT NOT NULL,
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
     updated_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT '',
-    updated_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system',
+    updated_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_sites_name ON sites(name);
@@ -28,8 +28,8 @@ CREATE TABLE categories (
     name TEXT NOT NULL,
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
     updated_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT '',
-    updated_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system',
+    updated_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_categories_name ON categories(name);
@@ -45,8 +45,8 @@ CREATE TABLE packaging_types (
     display_order INTEGER NOT NULL DEFAULT 0,
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
     updated_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT,
-    updated_by TEXT
+    created_by TEXT NOT NULL DEFAULT 'system',
+    updated_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_packaging_types_active ON packaging_types(is_active);
@@ -66,8 +66,8 @@ CREATE TABLE app_users (
     is_active BOOLEAN NOT NULL DEFAULT TRUE,
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
     updated_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT '',
-    updated_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system',
+    updated_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_users_username ON app_users(username);
@@ -84,8 +84,8 @@ CREATE TABLE user_permissions (
     can_delete BOOLEAN NOT NULL DEFAULT FALSE,
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
     updated_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT '',
-    updated_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system',
+    updated_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_user_permissions_user ON user_permissions(user_id);
@@ -103,7 +103,7 @@ CREATE TABLE customers (
     notes TEXT,
     site_id UUID NOT NULL REFERENCES sites(id) ON DELETE RESTRICT,
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_customers_site ON customers(site_id);
@@ -139,8 +139,8 @@ CREATE TABLE products (
 
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
     updated_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT '',
-    updated_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system',
+    updated_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_products_site ON products(site_id);
@@ -158,8 +158,8 @@ CREATE TABLE product_prices (
     source TEXT NOT NULL, -- "manual" or "calculated"
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
     updated_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT '',
-    updated_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system',
+    updated_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_product_prices_product ON product_prices(product_id);
@@ -184,8 +184,8 @@ CREATE TABLE purchase_batches (
     is_exhausted BOOLEAN NOT NULL DEFAULT FALSE,
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
     updated_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT '',
-    updated_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system',
+    updated_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_purchase_batches_product ON purchase_batches(product_id);
@@ -204,7 +204,7 @@ CREATE TABLE stock_movements (
     selling_price_at_movement DOUBLE PRECISION NOT NULL,
     site_id UUID NOT NULL REFERENCES sites(id) ON DELETE RESTRICT,
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_stock_movements_product ON stock_movements(product_id);
@@ -225,7 +225,7 @@ CREATE TABLE inventories (
     counted_by TEXT NOT NULL DEFAULT '',
     notes TEXT NOT NULL DEFAULT '',
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_inventories_product ON inventories(product_id);
@@ -243,8 +243,8 @@ CREATE TABLE product_transfers (
     notes TEXT NOT NULL DEFAULT '',
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
     updated_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT '',
-    updated_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system',
+    updated_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_product_transfers_product ON product_transfers(product_id);
@@ -265,7 +265,7 @@ CREATE TABLE sales (
     total_amount DOUBLE PRECISION NOT NULL,
     site_id UUID NOT NULL REFERENCES sites(id) ON DELETE RESTRICT,
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_sales_customer ON sales(customer_id);
@@ -310,7 +310,7 @@ CREATE TABLE product_sales (
     date BIGINT NOT NULL,
     site_id UUID NOT NULL REFERENCES sites(id) ON DELETE RESTRICT,
     created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT * 1000,
-    created_by TEXT NOT NULL DEFAULT ''
+    created_by TEXT NOT NULL DEFAULT 'system'
 );
 
 CREATE INDEX idx_product_sales_product ON product_sales(product_id);
@@ -354,6 +354,39 @@ BEGIN
 END;
 $$ language 'plpgsql';
 
+-- Fonction pour définir created_by/updated_by à "system" si absent
+CREATE OR REPLACE FUNCTION set_audit_user_defaults()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.created_by IS NULL OR NEW.created_by = '' THEN
+        NEW.created_by = 'system';
+    END IF;
+
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.updated_by IS NULL OR NEW.updated_by = '' THEN
+            NEW.updated_by = NEW.created_by;
+        END IF;
+    ELSE
+        IF NEW.updated_by IS NULL OR NEW.updated_by = '' THEN
+            NEW.updated_by = 'system';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- Fonction pour définir created_by à "system" si absent
+CREATE OR REPLACE FUNCTION set_created_by_default()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.created_by IS NULL OR NEW.created_by = '' THEN
+        NEW.created_by = 'system';
+    END IF;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
 -- Appliquer le trigger sur toutes les tables avec updated_at
 CREATE TRIGGER update_sites_updated_at BEFORE UPDATE ON sites
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
@@ -381,6 +414,49 @@ CREATE TRIGGER update_purchase_batches_updated_at BEFORE UPDATE ON purchase_batc
 
 CREATE TRIGGER update_product_transfers_updated_at BEFORE UPDATE ON product_transfers
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Appliquer le trigger pour created_by/updated_by
+CREATE TRIGGER set_sites_audit_defaults BEFORE INSERT OR UPDATE ON sites
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+CREATE TRIGGER set_categories_audit_defaults BEFORE INSERT OR UPDATE ON categories
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+CREATE TRIGGER set_packaging_types_audit_defaults BEFORE INSERT OR UPDATE ON packaging_types
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+CREATE TRIGGER set_app_users_audit_defaults BEFORE INSERT OR UPDATE ON app_users
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+CREATE TRIGGER set_user_permissions_audit_defaults BEFORE INSERT OR UPDATE ON user_permissions
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+CREATE TRIGGER set_products_audit_defaults BEFORE INSERT OR UPDATE ON products
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+CREATE TRIGGER set_product_prices_audit_defaults BEFORE INSERT OR UPDATE ON product_prices
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+CREATE TRIGGER set_purchase_batches_audit_defaults BEFORE INSERT OR UPDATE ON purchase_batches
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+CREATE TRIGGER set_product_transfers_audit_defaults BEFORE INSERT OR UPDATE ON product_transfers
+    FOR EACH ROW EXECUTE FUNCTION set_audit_user_defaults();
+
+CREATE TRIGGER set_customers_created_by BEFORE INSERT ON customers
+    FOR EACH ROW EXECUTE FUNCTION set_created_by_default();
+
+CREATE TRIGGER set_stock_movements_created_by BEFORE INSERT ON stock_movements
+    FOR EACH ROW EXECUTE FUNCTION set_created_by_default();
+
+CREATE TRIGGER set_inventories_created_by BEFORE INSERT ON inventories
+    FOR EACH ROW EXECUTE FUNCTION set_created_by_default();
+
+CREATE TRIGGER set_sales_created_by BEFORE INSERT ON sales
+    FOR EACH ROW EXECUTE FUNCTION set_created_by_default();
+
+CREATE TRIGGER set_product_sales_created_by BEFORE INSERT ON product_sales
+    FOR EACH ROW EXECUTE FUNCTION set_created_by_default();
 
 -- ============================================================================
 -- VUES UTILES


### PR DESCRIPTION
### Motivation
- Ensure database rows created from the app carry the actual user name (or `system` fallback) instead of empty strings for `createdBy`/`updatedBy`.
- Preserve original creator metadata when updating records from the app so `createdAt`/`createdBy` are not lost on edits.
- Ensure Supabase schema enforces sensible defaults server-side and backfills existing rows to avoid empty `created_by`/`updated_by` values.
- Provide triggers to automatically set audit fields when inserts/updates occur directly in the database.

### Description
- Filled `createdBy`/`updatedBy` in Android creation/update flows by using `AuthManager.getInstance(...).getUsername()` with a `'system'` fallback in activities including `SiteAddEditActivity`, `SiteSelectorActivity`, `CategoryAddEditActivity`, `ProductAddActivity`, `ProductAddEditActivity`, `PackagingTypeAddEditActivity`, `PurchaseActivity`, `StockMovementActivity`, `InventoryActivity`, `SaleActivity`, and `SaleListActivity`.
- Preserve creator metadata on updates by reusing `existing*.createdAt` and `existing*.createdBy` where available and updating `updatedAt`/`updatedBy` to the current user.
- Updated `ProductViewModel.addProductWithPrice` to attribute `Product` and generated `ProductPrice` records to the current user when needed.
- Modified `supabase-schema.sql` to set `created_by`/`updated_by` defaults to `'system'`, added trigger functions `set_audit_user_defaults` and `set_created_by_default`, applied triggers for relevant tables, and added a migration script `supabase-created-updated-by-migration.sql` that backfills existing rows and sets column defaults and triggers.

### Testing
- No automated tests were executed as part of this change set.
- Changes were limited to code and SQL migration files; runtime validation or CI build was not performed in this rollout.
- The migration script `supabase-created-updated-by-migration.sql` was added to backfill and enforce defaults on the Supabase database.
- Manual verification steps (build/run) were not run here and should be performed after merging to confirm behavior in the app and database.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69497d088ea8832699868a5d9fce55c4)