### PR TITLE
Enable automatic Supabase sync with online fallback

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation "androidx.activity:activity-ktx:1.7.2"
     implementation "androidx.gridlayout:gridlayout:1.0.0"
     implementation "androidx.preference:preference-ktx:1.2.1"
+    implementation "androidx.work:work-runtime-ktx:2.9.0"
 
     // RecyclerView and CardView
     implementation "androidx.recyclerview:recyclerview:1.3.1"

--- a/app/src/main/java/com/medistock/MedistockApplication.kt
+++ b/app/src/main/java/com/medistock/MedistockApplication.kt
@@ -2,6 +2,7 @@ package com.medistock
 
 import android.app.Application
 import com.medistock.data.remote.SupabaseClientProvider
+import com.medistock.data.sync.SyncScheduler
 
 /**
  * Classe Application pour Medistock
@@ -17,14 +18,17 @@ class MedistockApplication : Application() {
         try {
             SupabaseClientProvider.initialize(this)
             println("✅ Application démarrée avec Supabase 2.2.2")
+            SyncScheduler.start(this)
         } catch (e: IllegalStateException) {
             // Les credentials Supabase ne sont pas encore configurés
             println("⚠️ Supabase non configuré: ${e.message}")
             println("⚠️ Veuillez configurer Supabase dans Administration > Configuration Supabase")
+            SyncScheduler.start(this)
         } catch (e: Exception) {
             // Autre erreur lors de l'initialisation
             println("❌ Erreur lors de l'initialisation Supabase: ${e.message}")
             e.printStackTrace()
+            SyncScheduler.start(this)
         }
     }
 }

--- a/app/src/main/java/com/medistock/data/sync/AutoSyncWorker.kt
+++ b/app/src/main/java/com/medistock/data/sync/AutoSyncWorker.kt
@@ -30,6 +30,8 @@ class AutoSyncWorker(
             }
         )
 
+        SyncScheduler.scheduleNext(applicationContext)
+
         return if (hasError) Result.retry() else Result.success()
     }
 }

--- a/app/src/main/java/com/medistock/data/sync/AutoSyncWorker.kt
+++ b/app/src/main/java/com/medistock/data/sync/AutoSyncWorker.kt
@@ -1,0 +1,35 @@
+package com.medistock.data.sync
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.medistock.data.remote.SupabaseClientProvider
+import com.medistock.util.NetworkStatus
+
+class AutoSyncWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        if (!SupabaseClientProvider.isConfigured(applicationContext)) {
+            return Result.success()
+        }
+
+        if (!NetworkStatus.isOnline(applicationContext)) {
+            return Result.retry()
+        }
+
+        SupabaseClientProvider.reinitialize(applicationContext)
+
+        val syncManager = SyncManager(applicationContext)
+        var hasError = false
+        syncManager.fullSync(
+            onError = { _, _ ->
+                hasError = true
+            }
+        )
+
+        return if (hasError) Result.retry() else Result.success()
+    }
+}

--- a/app/src/main/java/com/medistock/data/sync/SyncManager.kt
+++ b/app/src/main/java/com/medistock/data/sync/SyncManager.kt
@@ -6,6 +6,7 @@ import com.medistock.data.remote.SupabaseClientProvider
 import com.medistock.data.remote.repository.*
 import com.medistock.data.sync.SyncMapper.toDto
 import com.medistock.data.sync.SyncMapper.toEntity
+import com.medistock.util.NetworkStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
@@ -39,6 +40,11 @@ class SyncManager(
         try {
             if (!SupabaseClientProvider.isConfigured(context)) {
                 onError?.invoke("Supabase", Exception("Supabase n'est pas configuré"))
+                return@withContext
+            }
+
+            if (!NetworkStatus.isOnline(context)) {
+                onError?.invoke("Connexion", Exception("Connexion indisponible. Mode local actif."))
                 return@withContext
             }
 
@@ -79,6 +85,11 @@ class SyncManager(
         try {
             if (!SupabaseClientProvider.isConfigured(context)) {
                 onError?.invoke("Supabase", Exception("Supabase n'est pas configuré"))
+                return@withContext
+            }
+
+            if (!NetworkStatus.isOnline(context)) {
+                onError?.invoke("Connexion", Exception("Connexion indisponible. Mode local actif."))
                 return@withContext
             }
 

--- a/app/src/main/java/com/medistock/data/sync/SyncScheduler.kt
+++ b/app/src/main/java/com/medistock/data/sync/SyncScheduler.kt
@@ -1,0 +1,109 @@
+package com.medistock.data.sync
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.util.Log
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import com.medistock.data.remote.SupabaseClientProvider
+import com.medistock.util.NetworkStatus
+import com.medistock.util.SupabasePreferences
+import java.util.concurrent.TimeUnit
+
+object SyncScheduler {
+    private const val PERIODIC_SYNC_WORK = "auto_sync_periodic"
+    private const val IMMEDIATE_SYNC_WORK = "auto_sync_immediate"
+    private const val TAG = "SyncScheduler"
+
+    private var networkCallbackRegistered = false
+
+    fun start(context: Context) {
+        val appContext = context.applicationContext
+        schedulePeriodic(appContext)
+        updateSyncMode(appContext, NetworkStatus.isOnline(appContext))
+        registerNetworkCallback(appContext)
+
+        if (SupabaseClientProvider.isConfigured(appContext) && NetworkStatus.isOnline(appContext)) {
+            triggerImmediate(appContext, "app-start")
+        }
+    }
+
+    fun schedulePeriodic(context: Context) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val request = PeriodicWorkRequestBuilder<AutoSyncWorker>(15, TimeUnit.MINUTES)
+            .setConstraints(constraints)
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            PERIODIC_SYNC_WORK,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
+        )
+    }
+
+    fun triggerImmediate(context: Context, reason: String) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val request = OneTimeWorkRequestBuilder<AutoSyncWorker>()
+            .setConstraints(constraints)
+            .setInputData(workDataOf("reason" to reason))
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            IMMEDIATE_SYNC_WORK,
+            ExistingWorkPolicy.REPLACE,
+            request
+        )
+    }
+
+    private fun registerNetworkCallback(context: Context) {
+        if (networkCallbackRegistered) {
+            return
+        }
+
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+        connectivityManager.registerDefaultNetworkCallback(
+            object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) {
+                    updateSyncMode(context, true)
+                    if (SupabaseClientProvider.isConfigured(context)) {
+                        SupabaseClientProvider.reinitialize(context)
+                        triggerImmediate(context, "network-available")
+                    }
+                }
+
+                override fun onLost(network: Network) {
+                    updateSyncMode(context, false)
+                }
+            }
+        )
+
+        networkCallbackRegistered = true
+        Log.d(TAG, "Network callback registered for auto sync")
+    }
+
+    private fun updateSyncMode(context: Context, isOnline: Boolean) {
+        val preferences = SupabasePreferences(context)
+        val configured = SupabaseClientProvider.isConfigured(context)
+        val mode = if (configured && isOnline) {
+            SupabasePreferences.SyncMode.REALTIME
+        } else {
+            SupabasePreferences.SyncMode.LOCAL
+        }
+        preferences.setSyncMode(mode)
+    }
+}

--- a/app/src/main/java/com/medistock/ui/admin/SupabaseConfigActivity.kt
+++ b/app/src/main/java/com/medistock/ui/admin/SupabaseConfigActivity.kt
@@ -11,6 +11,7 @@ import com.google.android.material.textfield.TextInputEditText
 import com.medistock.R
 import com.medistock.data.remote.SupabaseClientProvider
 import com.medistock.data.sync.SyncManager
+import com.medistock.data.sync.SyncScheduler
 import com.medistock.util.SupabasePreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -99,6 +100,8 @@ class SupabaseConfigActivity : AppCompatActivity() {
         // Reinitialize Supabase client with new configuration
         try {
             SupabaseClientProvider.reinitialize(this)
+            SyncScheduler.start(this)
+            SyncScheduler.triggerImmediate(this, "config-saved")
             showStatus("Configuration enregistrée avec succès!", true)
         } catch (e: Exception) {
             showStatus("Configuration enregistrée mais erreur d'initialisation: ${e.message}", false)

--- a/app/src/main/java/com/medistock/util/NetworkStatus.kt
+++ b/app/src/main/java/com/medistock/util/NetworkStatus.kt
@@ -1,0 +1,16 @@
+package com.medistock.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+object NetworkStatus {
+    fun isOnline(context: Context): Boolean {
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+}

--- a/app/src/main/java/com/medistock/util/SupabasePreferences.kt
+++ b/app/src/main/java/com/medistock/util/SupabasePreferences.kt
@@ -13,6 +13,12 @@ class SupabasePreferences(context: Context) {
         private const val KEY_URL = "supabase_url"
         private const val KEY_API_KEY = "supabase_key"
         private const val KEY_CONFIGURED = "is_configured"
+        private const val KEY_SYNC_MODE = "sync_mode"
+    }
+
+    enum class SyncMode {
+        REALTIME,
+        LOCAL
     }
 
     fun saveSupabaseConfig(url: String, apiKey: String) {
@@ -35,6 +41,17 @@ class SupabasePreferences(context: Context) {
         return preferences.getBoolean(KEY_CONFIGURED, false) &&
                 getSupabaseUrl().isNotEmpty() &&
                 getSupabaseKey().isNotEmpty()
+    }
+
+    fun setSyncMode(mode: SyncMode) {
+        preferences.edit()
+            .putString(KEY_SYNC_MODE, mode.name)
+            .apply()
+    }
+
+    fun getSyncMode(): SyncMode {
+        val stored = preferences.getString(KEY_SYNC_MODE, SyncMode.LOCAL.name) ?: SyncMode.LOCAL.name
+        return runCatching { SyncMode.valueOf(stored) }.getOrDefault(SyncMode.LOCAL)
     }
 
     fun clearConfiguration() {


### PR DESCRIPTION
### Motivation
- Provide automatic, periodic synchronization between local Room DB and Supabase so users don't have to press manual sync buttons. 
- Switch application sync mode between `REALTIME` and `LOCAL` based on network connectivity and Supabase configuration. 
- Avoid attempting remote sync operations when the device is offline to prevent errors and improve UX. 
- Trigger synchronization after Supabase configuration changes and when network becomes available. 

### Description
- Added a `NetworkStatus` utility and a `SyncMode` preference in `SupabasePreferences` with `setSyncMode`/`getSyncMode` methods. 
- Implemented `AutoSyncWorker` (WorkManager `CoroutineWorker`) and `SyncScheduler` to schedule periodic and immediate syncs and to register a network callback. 
- Guarded manual sync paths in `SyncManager` to check `NetworkStatus.isOnline` and return a descriptive error when offline. 
- Wired scheduler startup into application lifecycle by calling `SyncScheduler.start` from `MedistockApplication` and triggering an immediate sync from `SupabaseConfigActivity` after saving config, and added the `work-runtime-ktx` dependency in `build.gradle`. 

### Testing
- No automated tests were executed as part of this change. 
- Code was committed after implementing the new files and modifications (`AutoSyncWorker`, `SyncScheduler`, `NetworkStatus`, changes to `SyncManager`, `SupabasePreferences`, `SupabaseConfigActivity`, `MedistockApplication`, and `build.gradle`). 
- WorkManager constraints ensure syncs run only when network is available, and `SyncManager` now prevents remote sync attempts when offline. 
- Manual runtime verification is recommended to validate periodic scheduling, network-triggered immediate syncs, and mode switching between `REALTIME` and `LOCAL`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949840aafec8326b74a5bcde53b5a8e)