### PR TITLE
Fix Supabase sync crash when configuration is missing

### DIFF
--- a/app/src/main/java/com/medistock/data/sync/SyncManager.kt
+++ b/app/src/main/java/com/medistock/data/sync/SyncManager.kt
@@ -23,11 +23,11 @@ class SyncManager(
     private val scope = CoroutineScope(Dispatchers.IO)
 
     // Repositories Supabase
-    private val productRepo = ProductSupabaseRepository()
-    private val categoryRepo = CategorySupabaseRepository()
-    private val siteRepo = SiteSupabaseRepository()
-    private val customerRepo = CustomerSupabaseRepository()
-    private val packagingTypeRepo = PackagingTypeSupabaseRepository()
+    private val productRepo by lazy { ProductSupabaseRepository() }
+    private val categoryRepo by lazy { CategorySupabaseRepository() }
+    private val siteRepo by lazy { SiteSupabaseRepository() }
+    private val customerRepo by lazy { CustomerSupabaseRepository() }
+    private val packagingTypeRepo by lazy { PackagingTypeSupabaseRepository() }
 
     /**
      * Synchronise toutes les données de Room vers Supabase


### PR DESCRIPTION
## Summary
- lazily instantiate Supabase repositories in SyncManager to avoid accessing the client before configuration
- prevent SupabaseConfigActivity from crashing when the client has not been initialized yet

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b27f45ec8326a0ea45d190fb97ce)