### PR TITLE
Adopt Material3 theme for MediStock

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Theme.MediStock" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.MediStock" parent="Theme.Material3.DayNight">
         <!-- Couleurs Material Design 3 - Thème médical -->
         <item name="colorPrimary">@color/md_theme_primary</item>
         <item name="colorOnPrimary">@color/md_theme_onPrimary</item>


### PR DESCRIPTION
## Summary
- switch the app theme to inherit from Material3 DayNight so Material 3 widgets resolve their color attributes correctly

## Testing
- `./gradlew assembleDebug` *(fails: Gradle is configured with a Windows-only org.gradle.java.home path that is invalid in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b3b3846083268cfef81ed9a50bf9)