### PR TITLE
Add realtime diagnostics to admin Supabase config

### DIFF
--- a/app/src/main/res/layout/activity_supabase_config.xml
+++ b/app/src/main/res/layout/activity_supabase_config.xml
@@ -100,6 +100,30 @@
             android:visibility="gone"
             android:background="@android:color/transparent" />
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginTop="12dp">
+
+            <TextView
+                android:id="@+id/tvRealtimeStatus"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:padding="12dp"
+                android:text="Realtime non configuré"
+                android:background="@android:color/transparent" />
+
+            <Button
+                android:id="@+id/btnTestRealtime"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Tester Realtime" />
+        </LinearLayout>
+
         <!-- Divider -->
         <View
             android:layout_width="match_parent"

--- a/documentation/SUPABASE-README.md
+++ b/documentation/SUPABASE-README.md
@@ -300,6 +300,11 @@ Pour votre usage (50 produits, 10 sites, activité normale) :
 ### **Erreur réseau / timeout**
 ➡️ Vérifiez votre connexion Internet et les permissions Android
 
+### **Erreurs Realtime (canal fermé, token invalide)**
+➡️ Regénérez la clé **anon/public** dans **Settings → API** puis mettez à jour l'app (un token expiré provoque une coupure Realtime).  
+➡️ Vérifiez que vos tables sont bien dans la publication `supabase_realtime` (SQL Editor → `ALTER PUBLICATION supabase_realtime ADD TABLE votre_table;`).  
+➡️ Consultez les logs Android (`SupabaseConfig`) pour identifier si le canal est fermé ou si le token est refusé.
+
 ### **Données non synchronisées**
 ➡️ Vérifiez que les tables existent dans Supabase
 ➡️ Vérifiez que RLS est bien configuré


### PR DESCRIPTION
## Summary
- display realtime connection status in the admin Supabase configuration screen and add a dedicated ping action
- improve realtime diagnostics by logging token/closed-channel errors and surfacing status updates in the UI
- document troubleshooting steps for regenerating the anon key and checking the supabase_realtime publication

## Testing
- ./gradlew test *(fails: Value 'C:\\Program Files\\Java\\jdk-17' given for org.gradle.java.home Gradle property is invalid)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695455c39e288326a4db325d09f3243d)