### PR TITLE
Reset realtime session before connect and log status

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     implementation "io.ktor:ktor-client-core:$ktor_version"
     implementation "io.ktor:ktor-client-android:$ktor_version"
     implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"
+    implementation "io.ktor:ktor-client-websockets:$ktor_version"
     implementation "io.ktor:ktor-serialization-kotlinx-json:$ktor_version"
 
     // Kotlinx Serialization

--- a/app/src/main/java/com/medistock/ui/admin/SupabaseConfigActivity.kt
+++ b/app/src/main/java/com/medistock/ui/admin/SupabaseConfigActivity.kt
@@ -1,13 +1,14 @@
 package com.medistock.ui.admin
 
 import android.content.Context
-import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
 import android.view.MenuItem
 import android.widget.Button
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.edit
+import androidx.core.graphics.toColorInt
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.textfield.TextInputEditText
 import com.medistock.R
@@ -25,8 +26,8 @@ import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.withContext
 import io.github.jan.supabase.realtime.Realtime
-import io.github.jan.supabase.realtime.realtime
 import io.github.jan.supabase.realtime.channel
+import io.github.jan.supabase.realtime.realtime
 
 class SupabaseConfigActivity : AppCompatActivity() {
 
@@ -155,18 +156,18 @@ class SupabaseConfigActivity : AppCompatActivity() {
             try {
                 // Save temporarily to test
                 val tempPrefs = getSharedPreferences("temp_supabase_test", Context.MODE_PRIVATE)
-                tempPrefs.edit()
-                    .putString("url", url)
-                    .putString("key", key)
-                    .apply()
+                tempPrefs.edit {
+                    putString("url", url)
+                    putString("key", key)
+                }
 
                 // Try to create a client and make a simple query
-                val testClient = io.github.jan.supabase.createSupabaseClient(
+                io.github.jan.supabase.createSupabaseClient(
                     supabaseUrl = url,
                     supabaseKey = key
                 ) {
                     install(io.github.jan.supabase.postgrest.Postgrest)
-                }
+                }.close()
 
                 // Simple test - just check if we can connect
                 withContext(Dispatchers.Main) {
@@ -191,18 +192,23 @@ class SupabaseConfigActivity : AppCompatActivity() {
         lifecycleScope.launch(Dispatchers.IO) {
             try {
                 val client = SupabaseClientProvider.client
+                // Reset any previous session to avoid stale state
+                runCatching { client.realtime.disconnect() }
                 client.realtime.connect()
 
                 val connected = withTimeoutOrNull(5000) {
                     client.realtime.status.firstOrNull { status ->
-                        status == Realtime.Status.CONNECTED
-                    }
+                        status == Realtime.Status.CONNECTED || status == Realtime.Status.DISCONNECTED
+                    } == Realtime.Status.CONNECTED
                 }
 
-                if (connected == null) {
-                    Log.e(TAG, "Canal Realtime fermé ou en échec de connexion")
+                if (connected != true) {
+                    Log.e(TAG, "Canal Realtime fermé ou en échec de connexion: ${client.realtime.status.value}")
                     withContext(Dispatchers.Main) {
-                        updateRealtimeStatus("✗ Realtime inaccessible (timeout)", false)
+                        updateRealtimeStatus(
+                            "✗ Realtime inaccessible: statut ${client.realtime.status.value}",
+                            false
+                        )
                     }
                     return@launch
                 }
@@ -240,16 +246,16 @@ class SupabaseConfigActivity : AppCompatActivity() {
 
         when (isSuccess) {
             true -> {
-                tvStatus.setTextColor(Color.parseColor("#4CAF50"))
-                tvStatus.setBackgroundColor(Color.parseColor("#E8F5E9"))
+                tvStatus.setTextColor("#4CAF50".toColorInt())
+                tvStatus.setBackgroundColor("#E8F5E9".toColorInt())
             }
             false -> {
-                tvStatus.setTextColor(Color.parseColor("#F44336"))
-                tvStatus.setBackgroundColor(Color.parseColor("#FFEBEE"))
+                tvStatus.setTextColor("#F44336".toColorInt())
+                tvStatus.setBackgroundColor("#FFEBEE".toColorInt())
             }
             null -> {
-                tvStatus.setTextColor(Color.parseColor("#FF9800"))
-                tvStatus.setBackgroundColor(Color.parseColor("#FFF3E0"))
+                tvStatus.setTextColor("#FF9800".toColorInt())
+                tvStatus.setBackgroundColor("#FFF3E0".toColorInt())
             }
         }
     }
@@ -260,16 +266,16 @@ class SupabaseConfigActivity : AppCompatActivity() {
 
         when (isSuccess) {
             true -> {
-                tvRealtimeStatus.setTextColor(Color.parseColor("#4CAF50"))
-                tvRealtimeStatus.setBackgroundColor(Color.parseColor("#E8F5E9"))
+                tvRealtimeStatus.setTextColor("#4CAF50".toColorInt())
+                tvRealtimeStatus.setBackgroundColor("#E8F5E9".toColorInt())
             }
             false -> {
-                tvRealtimeStatus.setTextColor(Color.parseColor("#F44336"))
-                tvRealtimeStatus.setBackgroundColor(Color.parseColor("#FFEBEE"))
+                tvRealtimeStatus.setTextColor("#F44336".toColorInt())
+                tvRealtimeStatus.setBackgroundColor("#FFEBEE".toColorInt())
             }
             null -> {
-                tvRealtimeStatus.setTextColor(Color.parseColor("#FF9800"))
-                tvRealtimeStatus.setBackgroundColor(Color.parseColor("#FFF3E0"))
+                tvRealtimeStatus.setTextColor("#FF9800".toColorInt())
+                tvRealtimeStatus.setBackgroundColor("#FFF3E0".toColorInt())
             }
         }
     }
@@ -288,6 +294,25 @@ class SupabaseConfigActivity : AppCompatActivity() {
         }
 
         realtimeStatusJob = lifecycleScope.launch {
+            try {
+                val connected = withTimeoutOrNull(5000) {
+                    // Always start from a clean state before observing
+                    runCatching { client.realtime.disconnect() }
+                    client.realtime.connect()
+                    client.realtime.status.firstOrNull { status ->
+                        status == Realtime.Status.CONNECTED
+                    }
+                }
+                if (connected == null) {
+                    updateRealtimeStatus("Realtime inaccessible (timeout)", false)
+                    return@launch
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Impossible de connecter Realtime: ${e.message}", e)
+                updateRealtimeStatus("Realtime indisponible: ${e.message}", false)
+                return@launch
+            }
+
             client.realtime.status.collectLatest { status ->
                 val (message, success) = when (status) {
                     Realtime.Status.CONNECTED -> "Realtime connecté" to true
@@ -401,16 +426,16 @@ class SupabaseConfigActivity : AppCompatActivity() {
 
         when (isSuccess) {
             true -> {
-                tvSyncStatus.setTextColor(Color.parseColor("#4CAF50"))
-                tvSyncStatus.setBackgroundColor(Color.parseColor("#E8F5E9"))
+                tvSyncStatus.setTextColor("#4CAF50".toColorInt())
+                tvSyncStatus.setBackgroundColor("#E8F5E9".toColorInt())
             }
             false -> {
-                tvSyncStatus.setTextColor(Color.parseColor("#F44336"))
-                tvSyncStatus.setBackgroundColor(Color.parseColor("#FFEBEE"))
+                tvSyncStatus.setTextColor("#F44336".toColorInt())
+                tvSyncStatus.setBackgroundColor("#FFEBEE".toColorInt())
             }
             null -> {
-                tvSyncStatus.setTextColor(Color.parseColor("#2196F3"))
-                tvSyncStatus.setBackgroundColor(Color.parseColor("#E3F2FD"))
+                tvSyncStatus.setTextColor("#2196F3".toColorInt())
+                tvSyncStatus.setBackgroundColor("#E3F2FD".toColorInt())
             }
         }
     }


### PR DESCRIPTION
## Summary
- reset any existing realtime session before attempting connection to avoid stale state
- log the realtime status and surface the exact status in the UI when connection fails
- keep previous websocket dependency and KTX warning cleanups

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956551cf9988326a67f62d4d1c59732)