### PR TITLE
Add global profile badge with realtime status and popup actions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,7 +89,9 @@ dependencies {
     def ktor_version = "2.3.4"
     implementation "io.ktor:ktor-client-core:$ktor_version"
     implementation "io.ktor:ktor-client-android:$ktor_version"
+    implementation "io.ktor:ktor-client-okhttp:$ktor_version"
     implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"
+    implementation "io.ktor:ktor-client-websockets:$ktor_version"
     implementation "io.ktor:ktor-serialization-kotlinx-json:$ktor_version"
 
     // Kotlinx Serialization

--- a/app/src/main/java/com/medistock/MedistockApplication.kt
+++ b/app/src/main/java/com/medistock/MedistockApplication.kt
@@ -1,8 +1,12 @@
 package com.medistock
 
 import android.app.Application
+import android.app.Activity
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import com.medistock.data.remote.SupabaseClientProvider
 import com.medistock.data.sync.SyncScheduler
+import com.medistock.ui.common.UserProfileMenu
 
 /**
  * Classe Application pour Medistock
@@ -30,5 +34,19 @@ class MedistockApplication : Application() {
             e.printStackTrace()
             SyncScheduler.start(this)
         }
+
+        registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+                if (activity is AppCompatActivity) {
+                    UserProfileMenu.attach(activity)
+                }
+            }
+            override fun onActivityStarted(activity: Activity) {}
+            override fun onActivityResumed(activity: Activity) {}
+            override fun onActivityPaused(activity: Activity) {}
+            override fun onActivityStopped(activity: Activity) {}
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+            override fun onActivityDestroyed(activity: Activity) {}
+        })
     }
 }

--- a/app/src/main/java/com/medistock/data/remote/SupabaseClient.kt
+++ b/app/src/main/java/com/medistock/data/remote/SupabaseClient.kt
@@ -6,6 +6,7 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.realtime.Realtime
+import io.ktor.client.engine.okhttp.OkHttp
 
 /**
  * Client Supabase singleton pour Medistock
@@ -67,6 +68,7 @@ object SupabaseClientProvider {
                 supabaseUrl = supabaseUrl,
                 supabaseKey = supabaseKey
             ) {
+                httpEngine = OkHttp.create()
                 // Installation du module Postgrest pour les APIs REST
                 install(Postgrest)
 

--- a/app/src/main/java/com/medistock/ui/HomeActivity.kt
+++ b/app/src/main/java/com/medistock/ui/HomeActivity.kt
@@ -2,13 +2,9 @@ package com.medistock.ui
 
 import android.content.Intent
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuItem
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.medistock.R
 import com.medistock.ui.auth.LoginActivity
-import com.medistock.ui.auth.ChangePasswordActivity
 import com.medistock.ui.sales.SaleListActivity
 import com.medistock.ui.stock.StockListActivity
 import com.medistock.ui.purchase.PurchaseActivity
@@ -60,43 +56,6 @@ class HomeActivity : AppCompatActivity() {
         findViewById<android.view.View>(R.id.adminButton).setOnClickListener {
             startActivity(Intent(this, AdminActivity::class.java))
         }
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
-        menuInflater.inflate(R.menu.home_menu, menu)
-        return true
-    }
-
-    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
-        // Set user's full name in the menu
-        menu?.findItem(R.id.action_user_name)?.title = authManager.getFullName()
-        return super.onPrepareOptionsMenu(menu)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.action_change_password -> {
-                startActivity(Intent(this, ChangePasswordActivity::class.java))
-                true
-            }
-            R.id.action_logout -> {
-                showLogoutDialog()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
-
-    private fun showLogoutDialog() {
-        AlertDialog.Builder(this)
-            .setTitle("Logout")
-            .setMessage("Do you want to logout?")
-            .setPositiveButton("Yes") { _, _ ->
-                authManager.logout()
-                navigateToLogin()
-            }
-            .setNegativeButton("No", null)
-            .show()
     }
 
     private fun navigateToLogin() {

--- a/app/src/main/java/com/medistock/ui/common/UserProfileMenu.kt
+++ b/app/src/main/java/com/medistock/ui/common/UserProfileMenu.kt
@@ -1,0 +1,158 @@
+package com.medistock.ui.common
+
+import android.content.Intent
+import android.graphics.drawable.GradientDrawable
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuItem
+import android.widget.PopupMenu
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.graphics.toColorInt
+import androidx.core.view.MenuProvider
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.medistock.R
+import com.medistock.data.remote.SupabaseClientProvider
+import com.medistock.ui.auth.ChangePasswordActivity
+import com.medistock.ui.auth.LoginActivity
+import com.medistock.util.AuthManager
+import io.github.jan.supabase.realtime.Realtime
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import java.util.WeakHashMap
+
+/**
+ * Menu global affichant un badge rond avec l'initiale de l'utilisateur
+ * et l'état Realtime (vert connecté, rouge déconnecté).
+ * Cliquer sur le badge ouvre un menu permettant de voir le profil,
+ * changer le mot de passe et se déconnecter.
+ */
+object UserProfileMenu {
+
+    private val attached = WeakHashMap<AppCompatActivity, MenuProvider>()
+
+    fun attach(activity: AppCompatActivity) {
+        // Évite les doublons lors des recréations
+        if (attached.containsKey(activity)) return
+
+        val provider = object : MenuProvider {
+            private var statusJob: Job? = null
+
+            override fun onCreateMenu(menu: Menu, menuInflater: android.view.MenuInflater) {
+                if (menu.findItem(R.id.menu_profile_badge) != null) return
+
+                val item = menu.add(Menu.NONE, R.id.menu_profile_badge, Menu.NONE, "Profil")
+                item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+
+                val actionView = LayoutInflater.from(activity)
+                    .inflate(R.layout.menu_profile_badge, null)
+                val badge = actionView.findViewById<TextView>(R.id.tvProfileBadge)
+                item.actionView = actionView
+
+                configureBadge(badge, activity)
+                startRealtimeObservation(badge, activity)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean = false
+
+            private fun configureBadge(badge: TextView, activity: AppCompatActivity) {
+                val authManager = AuthManager.getInstance(activity)
+                val fullName = authManager.getFullName()
+                val initial = fullName.firstOrNull()?.uppercase() ?: "?"
+                badge.text = initial
+                applyStatus(badge, Realtime.Status.DISCONNECTED)
+
+                badge.setOnClickListener {
+                    showProfilePopup(activity, badge)
+                }
+            }
+
+            private fun startRealtimeObservation(badge: TextView, activity: AppCompatActivity) {
+                statusJob?.cancel()
+                statusJob = activity.lifecycleScope.launch {
+                    activity.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        val statusFlow = runCatching { SupabaseClientProvider.client.realtime.status }.getOrNull()
+                        if (statusFlow == null) {
+                            applyStatus(badge, Realtime.Status.DISCONNECTED)
+                            return@repeatOnLifecycle
+                        }
+                        statusFlow.collectLatest { status ->
+                            applyStatus(badge, status)
+                        }
+                    }
+                }
+            }
+
+            private fun showProfilePopup(activity: AppCompatActivity, anchor: TextView) {
+                val authManager = AuthManager.getInstance(activity)
+                val popup = PopupMenu(activity, anchor)
+                popup.menu.add(Menu.NONE, R.id.menu_profile_info, Menu.NONE, authManager.getFullName())
+                    .isEnabled = false
+                popup.menu.add(Menu.NONE, R.id.menu_change_password, Menu.NONE, activity.getString(R.string.change_password))
+                popup.menu.add(Menu.NONE, R.id.menu_logout, Menu.NONE, activity.getString(R.string.logout))
+
+                popup.setOnMenuItemClickListener { item ->
+                    when (item.itemId) {
+                        R.id.menu_change_password -> {
+                            activity.startActivity(Intent(activity, ChangePasswordActivity::class.java))
+                            true
+                        }
+                        R.id.menu_logout -> {
+                            showLogoutDialog(activity)
+                            true
+                        }
+                        else -> false
+                    }
+                }
+                popup.show()
+            }
+        }
+
+        activity.addMenuProvider(provider, activity, Lifecycle.State.RESUMED)
+        attached[activity] = provider
+    }
+
+    private fun applyStatus(badge: TextView, status: Realtime.Status) {
+        val background = (badge.background as? GradientDrawable)?.mutate()
+        when (status) {
+            Realtime.Status.CONNECTED -> {
+                background?.setStroke(3, "#4CAF50".toColorInt())
+                background?.setColor("#E8F5E9".toColorInt())
+                badge.setTextColor("#2E7D32".toColorInt())
+                badge.contentDescription = "Realtime connecté"
+            }
+            Realtime.Status.CONNECTING -> {
+                background?.setStroke(3, "#FFC107".toColorInt())
+                background?.setColor("#FFF8E1".toColorInt())
+                badge.setTextColor("#FF8F00".toColorInt())
+                badge.contentDescription = "Connexion Realtime..."
+            }
+            Realtime.Status.DISCONNECTED -> {
+                background?.setStroke(3, "#F44336".toColorInt())
+                background?.setColor("#FFEBEE".toColorInt())
+                badge.setTextColor("#C62828".toColorInt())
+                badge.contentDescription = "Realtime déconnecté"
+            }
+        }
+        badge.background = background
+    }
+
+    private fun showLogoutDialog(activity: AppCompatActivity) {
+        AlertDialog.Builder(activity)
+            .setTitle(R.string.logout)
+            .setMessage(R.string.logout_confirmation)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                AuthManager.getInstance(activity).logout()
+                val intent = Intent(activity, LoginActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                activity.startActivity(intent)
+                activity.finish()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+}

--- a/app/src/main/res/drawable/bg_profile_badge.xml
+++ b/app/src/main/res/drawable/bg_profile_badge.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#FFEBEE" />
+    <stroke android:width="3dp" android:color="#F44336" />
+    <size android:width="36dp" android:height="36dp" />
+</shape>

--- a/app/src/main/res/layout/activity_supabase_config.xml
+++ b/app/src/main/res/layout/activity_supabase_config.xml
@@ -9,13 +9,38 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <TextView
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Configuration Supabase"
-            android:textSize="24sp"
-            android:textStyle="bold"
-            android:layout_marginBottom="24dp" />
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Configuration Supabase"
+                android:textSize="24sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvRealtimeIndicator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:paddingTop="6dp"
+                android:paddingBottom="6dp"
+                android:text="Realtime déconnecté"
+                android:textSize="12sp"
+                android:background="@android:color/darker_gray"
+                android:textColor="@android:color/white"
+                android:layout_marginStart="12dp"
+                android:layout_marginEnd="4dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp" />
+        </LinearLayout>
 
         <TextView
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/menu_profile_badge.xml
+++ b/app/src/main/res/layout/menu_profile_badge.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/tvProfileBadge"
+    android:layout_width="40dp"
+    android:layout_height="40dp"
+    android:gravity="center"
+    android:padding="4dp"
+    android:text="?"
+    android:textSize="16sp"
+    android:textStyle="bold"
+    android:background="@drawable/bg_profile_badge"
+    android:contentDescription="Profil utilisateur" />

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="menu_profile_badge" type="id" />
+    <item name="menu_profile_info" type="id" />
+    <item name="menu_change_password" type="id" />
+    <item name="menu_logout" type="id" />
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,7 @@
     <string name="sell_product">Sell Product</string>
     <string name="manage_product">Manage Products</string>
     <string name="stock_movement">Stock Movement</string>
+    <string name="change_password">Change Password</string>
+    <string name="logout">Logout</string>
+    <string name="logout_confirmation">Do you want to logout?</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a global profile badge in the app bar that shows the user initial and realtime connection state (green/red)
- attach a popup from the badge to view profile info, change password, or logout, available on all screens
- wire application lifecycle to install the badge menu automatically across activities

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956551cf9988326a67f62d4d1c59732)