### PR TITLE
Fix login screen visibility

### DIFF
--- a/app/src/main/java/com/medistock/MedistockApplication.kt
+++ b/app/src/main/java/com/medistock/MedistockApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.app.Activity
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import com.medistock.data.remote.SupabaseClientProvider
 import com.medistock.data.sync.SyncScheduler
 import com.medistock.ui.auth.LoginActivity
@@ -26,6 +27,9 @@ class MedistockApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        // Force a light theme to match our defined palette (no dark variants yet)
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
 
         // Ensure modern trust store (Let's Encrypt, etc.) is available
         if (Security.getProvider("Conscrypt") == null) {

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -53,7 +53,7 @@
             android:text="Login"
             android:textSize="22sp"
             android:layout_marginBottom="20dp"
-            android:textColor="@android:color/black"/>
+            android:textColor="@color/md_theme_onBackground"/>
 
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
@@ -65,7 +65,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="Username"
-                android:inputType="text"/>
+                android:inputType="text"
+                android:textColor="@color/md_theme_onBackground"
+                android:textColorHint="@color/md_theme_onSurfaceVariant"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -78,7 +80,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="Password"
-                android:inputType="textPassword"/>
+                android:inputType="textPassword"
+                android:textColor="@color/md_theme_onBackground"
+                android:textColorHint="@color/md_theme_onSurfaceVariant"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button
@@ -87,7 +91,9 @@
             android:layout_height="wrap_content"
             android:text="Login"
             android:textSize="16sp"
-            android:padding="12dp"/>
+            android:padding="12dp"
+            android:backgroundTint="@color/md_theme_primary"
+            android:textColor="@android:color/white"/>
 
         <Button
             android:id="@+id/btnSupabaseConfig"
@@ -96,7 +102,9 @@
             android:text="Configurer Supabase"
             android:textSize="16sp"
             android:padding="12dp"
-            android:layout_marginTop="12dp"/>
+            android:layout_marginTop="12dp"
+            android:backgroundTint="@color/md_theme_secondary"
+            android:textColor="@color/md_theme_onSecondary"/>
 
         <TextView
             android:id="@+id/tvError"


### PR DESCRIPTION
## Summary
- Force the app to run in light mode so the existing color palette renders correctly.
- Explicitly set login form text and button colors to ensure the inputs stay visible.

## Testing
- ./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/17 test *(fails: Android SDK path not configured in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c0ed672608326b970fbab625c8460)