### PR TITLE
Fix app crash on Android back button

### DIFF
--- a/app/src/main/java/com/medistock/data/db/AuditTriggerInitializer.kt
+++ b/app/src/main/java/com/medistock/data/db/AuditTriggerInitializer.kt
@@ -65,22 +65,6 @@ object AuditTriggerInitializer {
             userColumns = listOf("updatedBy", "createdBy")
         ),
         TableConfig(
-            tableName = "product_sales",
-            columns = listOf(
-                "id",
-                "productId",
-                "quantity",
-                "priceAtSale",
-                "farmerName",
-                "date",
-                "siteId",
-                "createdAt",
-                "createdBy"
-            ),
-            siteIdColumn = "siteId",
-            userColumns = listOf("createdBy")
-        ),
-        TableConfig(
             tableName = "product_transfers",
             columns = listOf(
                 "id",


### PR DESCRIPTION
…rtup

The product_sales table was removed and replaced by sales + sale_items tables, but the AuditTriggerInitializer still tried to create triggers for it. This caused a SQLiteException on app startup as the table doesn't exist.