### PR TITLE
chore: Mettre à jour la version à 0.6.4 et simplifier le workflow de …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,19 +33,22 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-      - name: Update version in build.gradle
+      - name: Verify version in build.gradle
         run: |
-          # Extraire le versionCode actuel
-          CURRENT_VERSION_CODE=$(grep 'versionCode' app/build.gradle | awk '{print $2}')
-          # Incrémenter le versionCode
-          NEW_VERSION_CODE=$((CURRENT_VERSION_CODE + 1))
+          # Vérifier que la version dans build.gradle correspond au tag
+          BUILD_VERSION=$(grep 'versionName' app/build.gradle | sed 's/.*versionName "\(.*\)"/\1/')
+          TAG_VERSION="${{ steps.version.outputs.version }}"
 
-          # Mettre à jour build.gradle avec la nouvelle version
-          sed -i "s/versionCode $CURRENT_VERSION_CODE/versionCode $NEW_VERSION_CODE/" app/build.gradle
-          sed -i "s/versionName \".*\"/versionName \"${{ steps.version.outputs.version }}\"/" app/build.gradle
+          echo "Version dans build.gradle: $BUILD_VERSION"
+          echo "Version du tag: $TAG_VERSION"
 
-          echo "Updated versionCode from $CURRENT_VERSION_CODE to $NEW_VERSION_CODE"
-          echo "Updated versionName to ${{ steps.version.outputs.version }}"
+          if [ "$BUILD_VERSION" != "$TAG_VERSION" ]; then
+            echo "⚠️ ATTENTION: La version dans build.gradle ($BUILD_VERSION) ne correspond pas au tag ($TAG_VERSION)"
+            echo "Veuillez mettre à jour app/build.gradle avant de créer le tag."
+            exit 1
+          fi
+
+          echo "✅ Version vérifiée avec succès"
 
       - name: Build Release APK
         run: ./gradlew assembleRelease
@@ -90,11 +93,3 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit version bump
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add app/build.gradle
-          git commit -m "chore: bump version to ${{ steps.version.outputs.version }}" || echo "No changes to commit"
-          git push origin HEAD:main || echo "Could not push version bump"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.medistock"
         minSdk 26
         targetSdk 34
-        versionCode 7
-        versionName "0.6.0"
+        versionCode 8
+        versionName "0.6.4"
     }
 
     buildTypes {

--- a/documentation/RELEASE_GUIDE.md
+++ b/documentation/RELEASE_GUIDE.md
@@ -13,30 +13,51 @@ Ce guide explique comment créer des releases pour permettre la mise à jour aut
 
 ## 🤖 Méthode Automatique (Recommandée)
 
-Le workflow GitHub Actions automatise entièrement le processus de création de release.
+Le workflow GitHub Actions automatise le processus de création de release.
 
 ### Étapes :
 
-1. **Créer un tag de version**
+1. **Mettre à jour la version dans `app/build.gradle`**
+
+   **IMPORTANT** : Vous devez mettre à jour la version AVANT de créer le tag.
+
+   ```gradle
+   defaultConfig {
+       applicationId "com.medistock"
+       minSdk 26
+       targetSdk 34
+       versionCode 9        // Incrémenter de 1 à chaque release
+       versionName "0.7.0"  // Nouvelle version (SANS le préfixe "v")
+   }
+   ```
+
+2. **Committer et pousser les changements**
+   ```bash
+   git add app/build.gradle
+   git commit -m "chore: bump version to 0.7.0"
+   git push origin main
+   ```
+
+3. **Créer et pousser le tag de version**
    ```bash
    # Assurez-vous d'être sur la branche main
    git checkout main
    git pull origin main
 
    # Créer et pousser le tag (format: v1.2.3)
+   # ⚠️ Le tag doit correspondre au versionName dans build.gradle
    git tag v0.7.0
    git push origin v0.7.0
    ```
 
-2. **Le workflow GitHub Actions se déclenche automatiquement et va:**
-   - ✅ Mettre à jour le `versionCode` et `versionName` dans `build.gradle`
+4. **Le workflow GitHub Actions se déclenche automatiquement et va:**
+   - ✅ Vérifier que la version dans `build.gradle` correspond au tag
    - ✅ Compiler l'APK en mode release
    - ✅ Signer l'APK avec votre clé de signature
    - ✅ Créer une release GitHub avec l'APK attaché
    - ✅ Générer les notes de version automatiquement
-   - ✅ Committer la mise à jour de version sur la branche main
 
-3. **C'est tout !** La release est créée et disponible pour la mise à jour automatique.
+5. **C'est tout !** La release est créée et disponible pour la mise à jour automatique.
 
 ### Voir l'avancement :
 - Allez sur : https://github.com/kelplant/medistock-app/actions


### PR DESCRIPTION
…release

Problème :
- Le workflow tentait d'auto-incrémenter versionCode et versionName mais échouait à pousser les changements car il checkout le tag (état détaché)
- Cela causait une désynchronisation entre la version dans build.gradle et les releases GitHub

Corrections :
1. Mise à jour de build.gradle vers versionCode 8 et versionName "0.6.4" (correspond à la dernière release)
2. Simplification du workflow :
   - Suppression de l'auto-incrémentation de version
   - Ajout d'une vérification que build.gradle correspond au tag
   - Suppression de l'étape "Commit version bump" qui échouait
3. Mise à jour du RELEASE_GUIDE.md pour expliquer le nouveau processus

Nouveau processus :
1. Mettre à jour manuellement build.gradle (versionCode + versionName)
2. Committer et pousser les changements
3. Créer et pousser le tag
4. Le workflow se déclenche et crée la release automatiquement

Cette approche est plus simple, plus fiable et évite les problèmes de permissions Git.