### PR TITLE
Fix Kotlin language version compatibility issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,8 +44,39 @@ android {
         unitTests {
             includeAndroidResources = true
             returnDefaultValues = true
+            // Configure sqlite4java native library path for Robolectric LEGACY mode
+            all {
+                systemProperty 'sqlite4java.library.path', 'build/sqlite4java-libs'
+            }
         }
     }
+}
+
+// Task to extract sqlite4java native libraries for unit tests
+tasks.register('extractSqlite4JavaNativeLibs') {
+    doLast {
+        def targetDir = file("${buildDir}/sqlite4java-libs")
+        targetDir.mkdirs()
+
+        configurations.testRuntimeClasspath.files.findAll {
+            it.name.contains('libsqlite4java') || it.name.contains('sqlite4java-win')
+        }.each { jarFile ->
+            copy {
+                from zipTree(jarFile)
+                into targetDir
+                include '**/*.dll', '**/*.so', '**/*.dylib', '**/*.jnilib'
+                eachFile { fcp ->
+                    fcp.relativePath = new RelativePath(!fcp.file.isDirectory(), fcp.relativePath.lastName)
+                }
+                includeEmptyDirs = false
+            }
+        }
+    }
+}
+
+// Ensure native libs are extracted before running unit tests
+tasks.withType(Test).configureEach {
+    dependsOn 'extractSqlite4JavaNativeLibs'
 }
 
 kapt {
@@ -115,7 +146,12 @@ dependencies {
     testImplementation 'app.cash.turbine:turbine:1.0.0'
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'androidx.test.ext:junit:1.1.5'
-    testImplementation 'org.robolectric:robolectric:4.11.1'
+    testImplementation 'org.robolectric:robolectric:4.14.1'
+    // SQLite4java for Robolectric LEGACY mode (fixes UnsatisfiedLinkError on Windows)
+    testImplementation 'com.almworks.sqlite4java:sqlite4java:1.0.392'
+    testRuntimeOnly 'com.almworks.sqlite4java:libsqlite4java-win32-x64:1.0.392'
+    testRuntimeOnly 'com.almworks.sqlite4java:libsqlite4java-linux-amd64:1.0.392'
+    testRuntimeOnly 'com.almworks.sqlite4java:libsqlite4java-osx:1.0.392'
 
     // Android Instrumentation Testing
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,3 +1,6 @@
 # Robolectric configuration
-# Use SDK 33 for Robolectric tests (SDK 34 not fully supported yet)
+# Use SDK 33 for compatibility
 sdk=33
+# Use LEGACY SQLite mode to avoid native library loading issues on Windows
+# This uses sqlite4java instead of Robolectric's native SQLite
+sqlite.mode=LEGACY


### PR DESCRIPTION
…kError sur Windows

- Mise à jour de Robolectric vers 4.14.1
- Ajout de sqlite4java avec bibliothèques natives pour Windows/Linux/macOS
- Configuration du mode LEGACY dans robolectric.properties
- Tâche Gradle pour extraire les bibliothèques natives avant les tests
- Corrige le problème UnsatisfiedLinkError lors des tests unitaires JVM