### PR TITLE
fix: Simplifier la configuration - utiliser Robolectric 4.14.1 mode N…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,46 +44,7 @@ android {
         unitTests {
             includeAndroidResources = true
             returnDefaultValues = true
-            // Configure sqlite4java native library path for Robolectric LEGACY mode
-            all {
-                systemProperty 'sqlite4java.library.path', 'build/sqlite4java-libs'
-            }
         }
-    }
-}
-
-// Extract sqlite4java native libraries for unit tests after project evaluation
-afterEvaluate {
-    tasks.register('extractSqlite4JavaNativeLibs') {
-        doLast {
-            def targetDir = file("${buildDir}/sqlite4java-libs")
-            targetDir.mkdirs()
-
-            def configNames = ['testDebugRuntimeClasspath', 'testReleaseRuntimeClasspath']
-            configNames.each { configName ->
-                def testConfig = configurations.findByName(configName)
-                if (testConfig != null && testConfig.canBeResolved) {
-                    testConfig.files.findAll {
-                        it.name.contains('libsqlite4java') || it.name.contains('sqlite4java-win')
-                    }.each { jarFile ->
-                        copy {
-                            from zipTree(jarFile)
-                            into targetDir
-                            include '**/*.dll', '**/*.so', '**/*.dylib', '**/*.jnilib'
-                            eachFile { fcp ->
-                                fcp.relativePath = new RelativePath(!fcp.file.isDirectory(), fcp.relativePath.lastName)
-                            }
-                            includeEmptyDirs = false
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // Ensure native libs are extracted before running unit tests
-    tasks.withType(Test).configureEach {
-        dependsOn 'extractSqlite4JavaNativeLibs'
     }
 }
 
@@ -155,11 +116,6 @@ dependencies {
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'androidx.test.ext:junit:1.1.5'
     testImplementation 'org.robolectric:robolectric:4.14.1'
-    // SQLite4java for Robolectric LEGACY mode (fixes UnsatisfiedLinkError on Windows)
-    testImplementation 'com.almworks.sqlite4java:sqlite4java:1.0.392'
-    testRuntimeOnly 'com.almworks.sqlite4java:libsqlite4java-win32-x64:1.0.392'
-    testRuntimeOnly 'com.almworks.sqlite4java:libsqlite4java-linux-amd64:1.0.392'
-    testRuntimeOnly 'com.almworks.sqlite4java:libsqlite4java-osx:1.0.392'
 
     // Android Instrumentation Testing
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,6 +1,3 @@
 # Robolectric configuration
 # Use SDK 33 for compatibility
 sdk=33
-# Use LEGACY SQLite mode to avoid native library loading issues on Windows
-# This uses sqlite4java instead of Robolectric's native SQLite
-sqlite.mode=LEGACY


### PR DESCRIPTION
…ATIVE

- Retirer sqlite4java (artifacts non disponibles sur Maven)
- Retirer le mode LEGACY et la tâche d'extraction
- Robolectric 4.14.1 inclut ses propres bibliothèques natives SQLite