### PR TITLE
refactor: Déplacer les tests Room/Context vers androidTest

### DIFF
--- a/app/src/androidTest/java/com/medistock/data/dao/FifoAllocationTest.kt
+++ b/app/src/androidTest/java/com/medistock/data/dao/FifoAllocationTest.kt
@@ -3,7 +3,7 @@ package com.medistock.data.dao
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import org.robolectric.RobolectricTestRunner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.PurchaseBatch
 import com.medistock.data.entities.SaleBatchAllocation
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith
  * Tests the critical business logic for pharmaceutical inventory management.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class FifoAllocationTest {
 
     @get:Rule

--- a/app/src/androidTest/java/com/medistock/data/dao/ProductDaoTest.kt
+++ b/app/src/androidTest/java/com/medistock/data/dao/ProductDaoTest.kt
@@ -3,7 +3,7 @@ package com.medistock.data.dao
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import org.robolectric.RobolectricTestRunner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.Category
 import com.medistock.data.entities.Product
@@ -18,7 +18,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ProductDaoTest {
 
     @get:Rule

--- a/app/src/androidTest/java/com/medistock/data/dao/PurchaseBatchDaoTest.kt
+++ b/app/src/androidTest/java/com/medistock/data/dao/PurchaseBatchDaoTest.kt
@@ -3,7 +3,7 @@ package com.medistock.data.dao
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import org.robolectric.RobolectricTestRunner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.PurchaseBatch
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,7 +17,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PurchaseBatchDaoTest {
 
     @get:Rule

--- a/app/src/androidTest/java/com/medistock/data/dao/SaleDaoTest.kt
+++ b/app/src/androidTest/java/com/medistock/data/dao/SaleDaoTest.kt
@@ -3,7 +3,7 @@ package com.medistock.data.dao
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import org.robolectric.RobolectricTestRunner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.Sale
 import com.medistock.data.entities.SaleItem
@@ -18,7 +18,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SaleDaoTest {
 
     @get:Rule

--- a/app/src/androidTest/java/com/medistock/data/repository/AuditedProductRepositoryTest.kt
+++ b/app/src/androidTest/java/com/medistock/data/repository/AuditedProductRepositoryTest.kt
@@ -2,11 +2,9 @@ package com.medistock.data.repository
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import org.robolectric.RobolectricTestRunner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.medistock.data.db.AppDatabase
 import com.medistock.data.entities.Product
-import com.medistock.util.AuditLogger
-import com.medistock.util.AuthManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -17,7 +15,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AuditedProductRepositoryTest {
 
     private lateinit var repository: AuditedProductRepository

--- a/app/src/androidTest/java/com/medistock/data/sync/SyncManagerTest.kt
+++ b/app/src/androidTest/java/com/medistock/data/sync/SyncManagerTest.kt
@@ -2,7 +2,7 @@ package com.medistock.data.sync
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import org.robolectric.RobolectricTestRunner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith
  * Basic tests for SyncManager structure and initialization.
  * Full integration tests would require a Supabase instance.
  */
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class SyncManagerTest {
 
     private lateinit var context: Context

--- a/app/src/androidTest/java/com/medistock/ui/viewmodel/ProductViewModelTest.kt
+++ b/app/src/androidTest/java/com/medistock/ui/viewmodel/ProductViewModelTest.kt
@@ -2,7 +2,7 @@ package com.medistock.ui.viewmodel
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
-import org.robolectric.RobolectricTestRunner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.medistock.data.entities.Product
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -12,7 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ProductViewModelTest {
 
     private lateinit var viewModel: ProductViewModel

--- a/app/src/androidTest/java/com/medistock/util/AuthManagerTest.kt
+++ b/app/src/androidTest/java/com/medistock/util/AuthManagerTest.kt
@@ -1,9 +1,8 @@
 package com.medistock.util
 
 import android.content.Context
-import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
-import org.robolectric.RobolectricTestRunner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.medistock.data.entities.User
 import org.junit.After
 import org.junit.Assert.*
@@ -11,7 +10,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class AuthManagerTest {
 
     private lateinit var authManager: AuthManager


### PR DESCRIPTION
Les tests utilisant Room/SQLite et le Context Android sont déplacés vers androidTest (tests instrumentés) car Robolectric a des problèmes de bibliothèques natives sur Windows.

Tests déplacés:
- FifoAllocationTest, ProductDaoTest, PurchaseBatchDaoTest, SaleDaoTest
- AuditedProductRepositoryTest
- ProductViewModelTest
- AuthManagerTest, SyncManagerTest

Tests unitaires conservés (pas de dépendances Android natives):
- EntityValidationTest
- PasswordHasherTest
- PermissionManagerTest