### PR TITLE
Add unit tests to APK build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,12 @@ jobs:
 
           echo "✅ Version vérifiée avec succès"
 
+      - name: Run Unit Tests
+        run: |
+          echo "🧪 Exécution des tests unitaires..."
+          ./gradlew testDebugUnitTest --no-daemon
+          echo "✅ Tests unitaires réussis"
+
       - name: Build Release APK
         run: ./gradlew assembleRelease
 


### PR DESCRIPTION
Les tests unitaires seront maintenant exécutés automatiquement lors du workflow de release avant de construire l'APK. Si les tests échouent, la génération de l'APK sera annulée.