### PR TITLE
Fix KotlinLong expiry comparison & mark Identifiable extensions @retroactive

### DIFF
--- a/iosApp/iosApp/Views/ProductsViews.swift
+++ b/iosApp/iosApp/Views/ProductsViews.swift
@@ -308,4 +308,4 @@ struct ProductEditorView: View {
     }
 }
 
-extension Product: Identifiable {}
+extension Product: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/SitesViews.swift
+++ b/iosApp/iosApp/Views/SitesViews.swift
@@ -211,4 +211,4 @@ struct SiteEditorView: View {
     }
 }
 
-extension Site: Identifiable {}
+extension Site: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/StockViews.swift
+++ b/iosApp/iosApp/Views/StockViews.swift
@@ -123,7 +123,7 @@ struct StockListView: View {
 
                 // Get batches for expiry info
                 let productBatches = batches.filter { $0.productId == product.id && !$0.isExhausted }
-                let nearestExpiry = productBatches.compactMap { $0.expiryDate }.min()
+                let nearestExpiry = productBatches.compactMap { $0.expiryDate?.int64Value }.min()
 
                 items.append(StockItem(
                     productId: product.id,
@@ -371,7 +371,7 @@ struct StockMovementRowView: View {
     }
 }
 
-extension StockMovement: Identifiable {}
-extension CurrentStock: Identifiable {
+extension StockMovement: @retroactive Identifiable {}
+extension CurrentStock: @retroactive Identifiable {
     public var id: String { "\(productId)-\(siteId)" }
 }


### PR DESCRIPTION
### Motivation
- Resolve a Swift compile-time error when calling `min()` on a sequence of Kotlin `Long` wrappers by converting to a native integer type before comparison.
- Silence warnings about extending imported types with protocol conformances by making those conformances retroactive to avoid potential future conflicts with the `shared` module.

### Description
- Convert expiry timestamps from `KotlinLong` to native `Int64` in `iosApp/iosApp/Views/StockViews.swift` by replacing `productBatches.compactMap { $0.expiryDate }.min()` with `productBatches.compactMap { $0.expiryDate?.int64Value }.min()`.
- Mark `StockMovement` and `CurrentStock` conformances as `@retroactive Identifiable` in `iosApp/iosApp/Views/StockViews.swift`, preserving the custom `id` implementation for `CurrentStock`.
- Mark `Site` and `Product` conformances as `@retroactive Identifiable` in `iosApp/iosApp/Views/SitesViews.swift` and `iosApp/iosApp/Views/ProductsViews.swift` respectively to silence the warnings.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970a13db3608326bc458bf50bf10c5e)