### PR TITLE
Fix KotlinLong handling, add iOS16 notes fallback, mark Identifiable @retroactive, and add Xcode script outputs

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/shared.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -232,6 +233,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/shared.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/iosApp/iosApp/Views/AuditViews.swift
+++ b/iosApp/iosApp/Views/AuditViews.swift
@@ -185,4 +185,4 @@ struct AuditEntryRowView: View {
     }
 }
 
-extension AuditEntry: Identifiable {}
+extension AuditEntry: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/CategoriesViews.swift
+++ b/iosApp/iosApp/Views/CategoriesViews.swift
@@ -209,4 +209,4 @@ struct CategoryEditorView: View {
     }
 }
 
-extension shared.Category: Identifiable {}
+extension shared.Category: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/CustomersViews.swift
+++ b/iosApp/iosApp/Views/CustomersViews.swift
@@ -268,4 +268,4 @@ struct CustomerEditorView: View {
     }
 }
 
-extension Customer: Identifiable {}
+extension Customer: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/InventoryCountViews.swift
+++ b/iosApp/iosApp/Views/InventoryCountViews.swift
@@ -119,10 +119,11 @@ struct InventoryListView: View {
     private func completeInventory(_ inventory: Inventory) {
         Task {
             do {
+                let completedAt = KotlinLong(value: Int64(Date().timeIntervalSince1970 * 1000))
                 try await sdk.inventoryRepository.updateStatus(
                     id: inventory.id,
                     status: "completed",
-                    completedAt: Int64(Date().timeIntervalSince1970 * 1000)
+                    completedAt: completedAt
                 )
                 await loadData()
             } catch {
@@ -160,9 +161,9 @@ struct InventoryRowView: View {
             }
 
             HStack {
-                Text("Démarré: \(formatDate(inventory.startedAt))")
+                Text("Démarré: \(formatDate(inventory.startedAt.int64Value))")
                 if let completed = inventory.completedAt {
-                    Text("• Terminé: \(formatDate(completed))")
+                    Text("• Terminé: \(formatDate(completed.int64Value))")
                 }
             }
             .font(.caption)
@@ -210,6 +211,16 @@ struct InventoryEditorView: View {
     @State private var isSaving = false
     @State private var errorMessage: String?
 
+    @ViewBuilder
+    private var notesField: some View {
+        if #available(iOS 16.0, *) {
+            TextField("Notes", text: $notes, axis: .vertical)
+                .lineLimit(3...6)
+        } else {
+            TextField("Notes", text: $notes)
+        }
+    }
+
     var body: some View {
         NavigationView {
             Form {
@@ -223,8 +234,7 @@ struct InventoryEditorView: View {
                 }
 
                 Section(header: Text("Notes (optionnel)")) {
-                    TextField("Notes", text: $notes, axis: .vertical)
-                        .lineLimit(3...6)
+                    notesField
                 }
 
                 if let errorMessage {
@@ -279,4 +289,4 @@ struct InventoryEditorView: View {
     }
 }
 
-extension Inventory: Identifiable {}
+extension Inventory: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/PackagingTypesViews.swift
+++ b/iosApp/iosApp/Views/PackagingTypesViews.swift
@@ -262,4 +262,4 @@ struct PackagingTypeEditorView: View {
     }
 }
 
-extension PackagingType: Identifiable {}
+extension PackagingType: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/ProductsViews.swift
+++ b/iosApp/iosApp/Views/ProductsViews.swift
@@ -308,4 +308,4 @@ struct ProductEditorView: View {
     }
 }
 
-extension Product: Identifiable {}
+extension Product: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/PurchasesViews.swift
+++ b/iosApp/iosApp/Views/PurchasesViews.swift
@@ -337,4 +337,4 @@ struct PurchaseEditorView: View {
     }
 }
 
-extension PurchaseBatch: Identifiable {}
+extension PurchaseBatch: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/SalesViews.swift
+++ b/iosApp/iosApp/Views/SalesViews.swift
@@ -583,5 +583,5 @@ struct SaleItemEditorView: View {
     }
 }
 
-extension Sale: Identifiable {}
-extension SaleItem: Identifiable {}
+extension Sale: @retroactive Identifiable {}
+extension SaleItem: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/SitesViews.swift
+++ b/iosApp/iosApp/Views/SitesViews.swift
@@ -211,4 +211,4 @@ struct SiteEditorView: View {
     }
 }
 
-extension Site: Identifiable {}
+extension Site: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/StockViews.swift
+++ b/iosApp/iosApp/Views/StockViews.swift
@@ -123,7 +123,7 @@ struct StockListView: View {
 
                 // Get batches for expiry info
                 let productBatches = batches.filter { $0.productId == product.id && !$0.isExhausted }
-                let nearestExpiry = productBatches.compactMap { $0.expiryDate }.min()
+                let nearestExpiry = productBatches.compactMap { $0.expiryDate?.int64Value }.min()
 
                 items.append(StockItem(
                     productId: product.id,
@@ -371,7 +371,7 @@ struct StockMovementRowView: View {
     }
 }
 
-extension StockMovement: Identifiable {}
-extension CurrentStock: Identifiable {
+extension StockMovement: @retroactive Identifiable {}
+extension CurrentStock: @retroactive Identifiable {
     public var id: String { "\(productId)-\(siteId)" }
 }

--- a/iosApp/iosApp/Views/TransfersViews.swift
+++ b/iosApp/iosApp/Views/TransfersViews.swift
@@ -397,4 +397,4 @@ struct TransferEditorView: View {
     }
 }
 
-extension ProductTransfer: Identifiable {}
+extension ProductTransfer: @retroactive Identifiable {}

--- a/iosApp/iosApp/Views/UsersViews.swift
+++ b/iosApp/iosApp/Views/UsersViews.swift
@@ -275,4 +275,4 @@ struct UserEditorView: View {
     }
 }
 
-extension User: Identifiable {}
+extension User: @retroactive Identifiable {}


### PR DESCRIPTION
### Motivation
- Prevent Swift type errors and runtime issues when bridging Kotlin `Long` values into Swift by converting/using the correct Kotlin wrapper types and native integer accessors.
- Provide a safe fallback for the iOS 16-only multiline `TextField` API to keep the editor usable on older iOS versions.
- Silence warnings about retroactive conformances of imported types to `Identifiable` to avoid incorrect behavior if the `shared` module later adds those conformances.
- Avoid Xcode build phases being run on every build by declaring outputs for the shared-framework script phases.

### Description
- Replace direct `Int64` usage when calling Kotlin APIs by constructing `KotlinLong(value: Int64(...))` for `updateStatus` and use `.int64Value` when formatting/reading timestamps (changes in `iosApp/iosApp/Views/InventoryCountViews.swift` and `iosApp/iosApp/Views/StockViews.swift`).
- Add a `notesField` `@ViewBuilder` with an `if #available(iOS 16.0, *)` branch to use the `TextField(..., axis:)` multiline API on iOS 16+ and fallback to the single-line `TextField` otherwise (in `InventoryEditorView`).
- Convert a set of `Identifiable` extensions on imported shared models to use `@retroactive Identifiable` for types: `Category`, `PurchaseBatch`, `Sale`, `SaleItem`, `ProductTransfer`, `User`, `Customer`, `PackagingType`, `AuditEntry`, `Inventory`, `Product`, `Site`, `StockMovement`, and `CurrentStock` across the app views.
- Add output paths to the `Run Shared Build Script` and `Embed Shared Framework` build phases in `iosApp/iosApp.xcodeproj/project.pbxproj` to avoid the "run every build" warnings by declaring produced framework paths.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970a13db3608326bc458bf50bf10c5e)