### PR TITLE
Use Int64 timestamps directly for inventory date formatting

### DIFF
--- a/iosApp/iosApp/Views/InventoryCountViews.swift
+++ b/iosApp/iosApp/Views/InventoryCountViews.swift
@@ -161,9 +161,9 @@ struct InventoryRowView: View {
             }
 
             HStack {
-                Text("Démarré: \(formatDate(inventory.startedAt.int64Value))")
+                Text("Démarré: \(formatDate(inventory.startedAt))")
                 if let completed = inventory.completedAt {
-                    Text("• Terminé: \(formatDate(completed.int64Value))")
+                    Text("• Terminé: \(formatDate(completed))")
                 }
             }
             .font(.caption)


### PR DESCRIPTION
### Motivation
- Fix a compile/runtime issue by removing erroneous `.int64Value` member access and using the `Int64` timestamps directly when formatting inventory dates.

### Description
- Updated `InventoryCountViews.swift` to pass `inventory.startedAt` and `inventory.completedAt` directly to `formatDate` instead of calling `.int64Value` on them.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c6ce077c8326ae11b069252ac674)