### PR TITLE
Add Int64.int64Value shim for KotlinLong interop

### DIFF
--- a/iosApp/iosApp/Int64Extensions.swift
+++ b/iosApp/iosApp/Int64Extensions.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension Int64 {
+    var int64Value: Int64 { self }
+}


### PR DESCRIPTION
### Motivation
- Provide compatibility for code that expects `.int64Value` (used for `KotlinLong`) and restore inventory date formatting to use `.int64Value`, resolving a type mismatch when formatting timestamps.

### Description
- Added `iosApp/iosApp/Int64Extensions.swift` containing `extension Int64 { var int64Value: Int64 { self } }` and updated `iosApp/iosApp/Views/InventoryCountViews.swift` to call `inventory.startedAt.int64Value` and `completed.int64Value` when passing timestamps to `formatDate`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c6ce077c8326ae11b069252ac674)