### PR TITLE
Unify timestamp formatting for KotlinLong and Int64

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		A100000EAAAA00010000000E /* AuditViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000EAAAA00000000000E /* AuditViews.swift */; };
 		A100000FAAAA00010000000F /* SupabaseViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000FAAAA00000000000F /* SupabaseViews.swift */; };
 		A1000010AAAA000100000010 /* CommonViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000010AAAA000000000010 /* CommonViews.swift */; };
+		A1000011AAAA000100000011 /* TimestampConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000011AAAA000000000011 /* TimestampConvertible.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +53,7 @@
 		A100000EAAAA00000000000E /* AuditViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditViews.swift; sourceTree = "<group>"; };
 		A100000FAAAA00000000000F /* SupabaseViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseViews.swift; sourceTree = "<group>"; };
 		A1000010AAAA000000000010 /* CommonViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonViews.swift; sourceTree = "<group>"; };
+		A1000011AAAA000000000011 /* TimestampConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimestampConvertible.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +97,7 @@
 			children = (
 				2152FB032600AC8F00CF470E /* MedistockApp.swift */,
 				2152FB052600AC8F00CF470E /* ContentView.swift */,
+				A1000011AAAA000000000011 /* TimestampConvertible.swift */,
 				A1VIEWS0000000000000000 /* Views */,
 				2152FB072600AC9000CF470E /* Assets.xcassets */,
 				2152FB0C2600AC9000CF470E /* Info.plist */,
@@ -264,6 +267,7 @@
 				A100000EAAAA00010000000E /* AuditViews.swift in Sources */,
 				A100000FAAAA00010000000F /* SupabaseViews.swift in Sources */,
 				A1000010AAAA000100000010 /* CommonViews.swift in Sources */,
+				A1000011AAAA000100000011 /* TimestampConvertible.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/TimestampConvertible.swift
+++ b/iosApp/iosApp/TimestampConvertible.swift
@@ -1,0 +1,14 @@
+import Foundation
+import shared
+
+protocol TimestampConvertible {
+    var timestampValue: Int64 { get }
+}
+
+extension Int64: TimestampConvertible {
+    var timestampValue: Int64 { self }
+}
+
+extension KotlinLong: TimestampConvertible {
+    var timestampValue: Int64 { int64Value }
+}

--- a/iosApp/iosApp/Views/AuditViews.swift
+++ b/iosApp/iosApp/Views/AuditViews.swift
@@ -176,8 +176,8 @@ struct AuditEntryRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .short

--- a/iosApp/iosApp/Views/InventoryCountViews.swift
+++ b/iosApp/iosApp/Views/InventoryCountViews.swift
@@ -161,9 +161,9 @@ struct InventoryRowView: View {
             }
 
             HStack {
-                Text("Démarré: \(formatDate(inventory.startedAt.int64Value))")
+                Text("Démarré: \(formatDate(inventory.startedAt))")
                 if let completed = inventory.completedAt {
-                    Text("• Terminé: \(formatDate(completed.int64Value))")
+                    Text("• Terminé: \(formatDate(completed))")
                 }
             }
             .font(.caption)
@@ -188,8 +188,8 @@ struct InventoryRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .short

--- a/iosApp/iosApp/Views/PurchasesViews.swift
+++ b/iosApp/iosApp/Views/PurchasesViews.swift
@@ -149,8 +149,8 @@ struct PurchaseBatchRowView: View {
             HStack {
                 Text("Date: \(formatDate(batch.purchaseDate))")
                 if let expiry = batch.expiryDate {
-                    Text("• Exp: \(formatDate(expiry.int64Value))")
-                        .foregroundColor(isExpiringSoon(expiry.int64Value) ? .orange : .secondary)
+                    Text("• Exp: \(formatDate(expiry))")
+                        .foregroundColor(isExpiringSoon(expiry) ? .orange : .secondary)
                 }
             }
             .font(.caption)
@@ -165,15 +165,15 @@ struct PurchaseBatchRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         return formatter.string(from: date)
     }
 
-    private func isExpiringSoon(_ timestamp: Int64) -> Bool {
-        let expiryDate = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func isExpiringSoon<T: TimestampConvertible>(_ timestamp: T) -> Bool {
+        let expiryDate = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let thirtyDaysFromNow = Calendar.current.date(byAdding: .day, value: 30, to: Date()) ?? Date()
         return expiryDate < thirtyDaysFromNow
     }

--- a/iosApp/iosApp/Views/SalesViews.swift
+++ b/iosApp/iosApp/Views/SalesViews.swift
@@ -130,8 +130,8 @@ struct SaleRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
@@ -209,8 +209,8 @@ struct SaleDetailView: View {
         products.first { $0.id == productId }?.name ?? "Produit inconnu"
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short

--- a/iosApp/iosApp/Views/StockViews.swift
+++ b/iosApp/iosApp/Views/StockViews.swift
@@ -123,7 +123,7 @@ struct StockListView: View {
 
                 // Get batches for expiry info
                 let productBatches = batches.filter { $0.productId == product.id && !$0.isExhausted }
-                let nearestExpiry = productBatches.compactMap { $0.expiryDate?.int64Value }.min()
+                let nearestExpiry = productBatches.compactMap { $0.expiryDate?.timestampValue }.min()
 
                 items.append(StockItem(
                     productId: product.id,
@@ -205,8 +205,8 @@ struct StockItemRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         return formatter.string(from: date)
@@ -362,8 +362,8 @@ struct StockMovementRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .short

--- a/iosApp/iosApp/Views/TransfersViews.swift
+++ b/iosApp/iosApp/Views/TransfersViews.swift
@@ -230,8 +230,8 @@ struct TransferRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .short


### PR DESCRIPTION
### Motivation
- Fix the type mismatch when passing `KotlinLong` timestamps to APIs that expect `Int64` and remove ad-hoc `.int64Value` usage by centralizing timestamp conversion.
- Make date formatting helpers accept both `Int64` and `KotlinLong` uniformly to reduce duplication and fragile casts.

### Description
- Add `TimestampConvertible.swift` which declares `TimestampConvertible` and provides conformances for `Int64` and `KotlinLong` (`timestampValue`), and remove the previous `Int64` shim file `Int64Extensions.swift`.
- Change `formatDate` helpers to the generic signature `formatDate<T: TimestampConvertible>(_:)` across views and update call sites to pass timestamp-compatible values directly (Inventory, Purchases, Stock, Audit, Transfers, Sales).
- Replace scattered `.int64Value` usage with `timestampValue` where appropriate (e.g. nearest expiry computation in `StockViews.swift`).
- Register the new `TimestampConvertible.swift` file in the Xcode project at `iosApp/iosApp.xcodeproj/project.pbxproj`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c6ce077c8326ae11b069252ac674)