### PR TITLE
Introduce TimestampConvertible and use LabeledContentCompat for iOS 15 compatibility

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		A100000EAAAA00010000000E /* AuditViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000EAAAA00000000000E /* AuditViews.swift */; };
 		A100000FAAAA00010000000F /* SupabaseViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000FAAAA00000000000F /* SupabaseViews.swift */; };
 		A1000010AAAA000100000010 /* CommonViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000010AAAA000000000010 /* CommonViews.swift */; };
+		A1000011AAAA000100000011 /* TimestampConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000011AAAA000000000011 /* TimestampConvertible.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +53,7 @@
 		A100000EAAAA00000000000E /* AuditViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditViews.swift; sourceTree = "<group>"; };
 		A100000FAAAA00000000000F /* SupabaseViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseViews.swift; sourceTree = "<group>"; };
 		A1000010AAAA000000000010 /* CommonViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonViews.swift; sourceTree = "<group>"; };
+		A1000011AAAA000000000011 /* TimestampConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimestampConvertible.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +97,7 @@
 			children = (
 				2152FB032600AC8F00CF470E /* MedistockApp.swift */,
 				2152FB052600AC8F00CF470E /* ContentView.swift */,
+				A1000011AAAA000000000011 /* TimestampConvertible.swift */,
 				A1VIEWS0000000000000000 /* Views */,
 				2152FB072600AC9000CF470E /* Assets.xcassets */,
 				2152FB0C2600AC9000CF470E /* Info.plist */,
@@ -264,6 +267,7 @@
 				A100000EAAAA00010000000E /* AuditViews.swift in Sources */,
 				A100000FAAAA00010000000F /* SupabaseViews.swift in Sources */,
 				A1000010AAAA000100000010 /* CommonViews.swift in Sources */,
+				A1000011AAAA000100000011 /* TimestampConvertible.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/TimestampConvertible.swift
+++ b/iosApp/iosApp/TimestampConvertible.swift
@@ -1,0 +1,14 @@
+import Foundation
+import shared
+
+protocol TimestampConvertible {
+    var timestampValue: Int64 { get }
+}
+
+extension Int64: TimestampConvertible {
+    var timestampValue: Int64 { self }
+}
+
+extension KotlinLong: TimestampConvertible {
+    var timestampValue: Int64 { int64Value }
+}

--- a/iosApp/iosApp/Views/AuditViews.swift
+++ b/iosApp/iosApp/Views/AuditViews.swift
@@ -176,8 +176,8 @@ struct AuditEntryRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .short

--- a/iosApp/iosApp/Views/InventoryCountViews.swift
+++ b/iosApp/iosApp/Views/InventoryCountViews.swift
@@ -161,9 +161,9 @@ struct InventoryRowView: View {
             }
 
             HStack {
-                Text("Démarré: \(formatDate(inventory.startedAt.int64Value))")
+                Text("Démarré: \(formatDate(inventory.startedAt))")
                 if let completed = inventory.completedAt {
-                    Text("• Terminé: \(formatDate(completed.int64Value))")
+                    Text("• Terminé: \(formatDate(completed))")
                 }
             }
             .font(.caption)
@@ -188,8 +188,8 @@ struct InventoryRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .short

--- a/iosApp/iosApp/Views/PurchasesViews.swift
+++ b/iosApp/iosApp/Views/PurchasesViews.swift
@@ -149,8 +149,8 @@ struct PurchaseBatchRowView: View {
             HStack {
                 Text("Date: \(formatDate(batch.purchaseDate))")
                 if let expiry = batch.expiryDate {
-                    Text("• Exp: \(formatDate(expiry.int64Value))")
-                        .foregroundColor(isExpiringSoon(expiry.int64Value) ? .orange : .secondary)
+                    Text("• Exp: \(formatDate(expiry))")
+                        .foregroundColor(isExpiringSoon(expiry) ? .orange : .secondary)
                 }
             }
             .font(.caption)
@@ -165,15 +165,15 @@ struct PurchaseBatchRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         return formatter.string(from: date)
     }
 
-    private func isExpiringSoon(_ timestamp: Int64) -> Bool {
-        let expiryDate = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func isExpiringSoon<T: TimestampConvertible>(_ timestamp: T) -> Bool {
+        let expiryDate = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let thirtyDaysFromNow = Calendar.current.date(byAdding: .day, value: 30, to: Date()) ?? Date()
         return expiryDate < thirtyDaysFromNow
     }

--- a/iosApp/iosApp/Views/SalesViews.swift
+++ b/iosApp/iosApp/Views/SalesViews.swift
@@ -130,8 +130,8 @@ struct SaleRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
@@ -153,9 +153,21 @@ struct SaleDetailView: View {
         NavigationView {
             List {
                 Section(header: Text("Informations")) {
-                    LabeledContent("Client", value: sale.customerName)
-                    LabeledContent("Total", value: String(format: "%.2f €", sale.totalAmount))
-                    LabeledContent("Date", value: formatDate(sale.date))
+                    LabeledContentCompat {
+                        Text("Client")
+                    } content: {
+                        Text(sale.customerName)
+                    }
+                    LabeledContentCompat {
+                        Text("Total")
+                    } content: {
+                        Text(String(format: "%.2f €", sale.totalAmount))
+                    }
+                    LabeledContentCompat {
+                        Text("Date")
+                    } content: {
+                        Text(formatDate(sale.date))
+                    }
                 }
 
                 if let items = saleWithItems?.items, !items.isEmpty {
@@ -209,8 +221,8 @@ struct SaleDetailView: View {
         products.first { $0.id == productId }?.name ?? "Produit inconnu"
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
@@ -520,7 +532,11 @@ struct SaleItemEditorView: View {
                     }
 
                     if !selectedProductId.isEmpty {
-                        LabeledContent("Stock disponible", value: String(format: "%.1f", availableStock))
+                        LabeledContentCompat {
+                            Text("Stock disponible")
+                        } content: {
+                            Text(String(format: "%.1f", availableStock))
+                        }
                     }
                 }
 
@@ -535,8 +551,16 @@ struct SaleItemEditorView: View {
                     Section(header: Text("Résumé")) {
                         let qty = Double(quantityText.replacingOccurrences(of: ",", with: ".")) ?? 0
                         let price = Double(priceText.replacingOccurrences(of: ",", with: ".")) ?? 0
-                        LabeledContent("Produit", value: product.name)
-                        LabeledContent("Total", value: String(format: "%.2f €", qty * price))
+                        LabeledContentCompat {
+                            Text("Produit")
+                        } content: {
+                            Text(product.name)
+                        }
+                        LabeledContentCompat {
+                            Text("Total")
+                        } content: {
+                            Text(String(format: "%.2f €", qty * price))
+                        }
                     }
                 }
             }

--- a/iosApp/iosApp/Views/StockViews.swift
+++ b/iosApp/iosApp/Views/StockViews.swift
@@ -123,7 +123,7 @@ struct StockListView: View {
 
                 // Get batches for expiry info
                 let productBatches = batches.filter { $0.productId == product.id && !$0.isExhausted }
-                let nearestExpiry = productBatches.compactMap { $0.expiryDate?.int64Value }.min()
+                let nearestExpiry = productBatches.compactMap { $0.expiryDate?.timestampValue }.min()
 
                 items.append(StockItem(
                     productId: product.id,
@@ -205,8 +205,8 @@ struct StockItemRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         return formatter.string(from: date)
@@ -362,8 +362,8 @@ struct StockMovementRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .short

--- a/iosApp/iosApp/Views/SupabaseViews.swift
+++ b/iosApp/iosApp/Views/SupabaseViews.swift
@@ -89,11 +89,15 @@ struct SupabaseConfigView: View {
                 }
 
                 Section(header: Text("État actuel")) {
-                    LabeledContent("URL configurée") {
+                    LabeledContentCompat {
+                        Text("URL configurée")
+                    } content: {
                         Text(UserDefaults.standard.string(forKey: urlKey)?.isEmpty == false ? "Oui" : "Non")
                             .foregroundColor(UserDefaults.standard.string(forKey: urlKey)?.isEmpty == false ? .green : .red)
                     }
-                    LabeledContent("Clé configurée") {
+                    LabeledContentCompat {
+                        Text("Clé configurée")
+                    } content: {
                         Text(UserDefaults.standard.string(forKey: keyKey)?.isEmpty == false ? "Oui" : "Non")
                             .foregroundColor(UserDefaults.standard.string(forKey: keyKey)?.isEmpty == false ? .green : .red)
                     }

--- a/iosApp/iosApp/Views/TransfersViews.swift
+++ b/iosApp/iosApp/Views/TransfersViews.swift
@@ -230,8 +230,8 @@ struct TransferRowView: View {
         .padding(.vertical, 4)
     }
 
-    private func formatDate(_ timestamp: Int64) -> String {
-        let date = Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    private func formatDate<T: TimestampConvertible>(_ timestamp: T) -> String {
+        let date = Date(timeIntervalSince1970: Double(timestamp.timestampValue) / 1000)
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .short
@@ -302,7 +302,11 @@ struct TransferEditorView: View {
                         }
 
                         if !selectedProductId.isEmpty {
-                            LabeledContent("Stock disponible", value: String(format: "%.1f", availableStock))
+                            LabeledContentCompat {
+                                Text("Stock disponible")
+                            } content: {
+                                Text(String(format: "%.1f", availableStock))
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation
- Centralize timestamp conversion so both `KotlinLong` and `Int64` can be passed to date helpers without ad-hoc casts or scattered `.int64Value` usage.
- Avoid Swift 6 availability errors caused by the iOS 16-only `LabeledContent` API while keeping UI compatible with iOS 15.

### Description
- Add `TimestampConvertible.swift` which declares `TimestampConvertible` and provides conformances for `Int64` and `KotlinLong`, and register the new file in the Xcode project.
- Make `formatDate` (and related helpers like `isExpiringSoon`) generic as `formatDate<T: TimestampConvertible>(_:)` and replace direct `.int64Value` accesses with `timestampValue` across views (`AuditViews`, `InventoryCountViews`, `PurchasesViews`, `StockViews`, `TransfersViews`, `SalesViews`, etc.).
- Replace usages of the iOS 16 `LabeledContent` with the existing `LabeledContentCompat` wrapper in `TransfersViews.swift`, `SalesViews.swift`, and `SupabaseViews.swift` to restore iOS 15 compatibility.
- Update related view code to use the new generic helpers and the compat wrapper to prevent availability errors.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c6ce077c8326ae11b069252ac674)