### PR TITLE
Fix iOS stock movement payload for Supabase schema

### DIFF
--- a/iosApp/iosApp/Sync/SyncDTOs.swift
+++ b/iosApp/iosApp/Sync/SyncDTOs.swift
@@ -528,6 +528,8 @@ struct StockMovementDTO: Codable {
     let siteId: String
     let quantity: Double
     let movementType: String
+    let purchasePriceAtMovement: Double
+    let sellingPriceAtMovement: Double
     let referenceId: String?
     let notes: String?
     let movementDate: Int64
@@ -540,10 +542,12 @@ struct StockMovementDTO: Codable {
         case productId = "product_id"
         case siteId = "site_id"
         case quantity
-        case movementType = "movement_type"
+        case movementType = "type"
+        case purchasePriceAtMovement = "purchase_price_at_movement"
+        case sellingPriceAtMovement = "selling_price_at_movement"
         case referenceId = "reference_id"
         case notes
-        case movementDate = "movement_date"
+        case movementDate = "date"
         case createdAt = "created_at"
         case createdBy = "created_by"
         case clientId = "client_id"
@@ -555,6 +559,8 @@ struct StockMovementDTO: Codable {
         self.siteId = movement.siteId
         self.quantity = movement.quantity
         self.movementType = movement.movementType
+        self.purchasePriceAtMovement = 0.0
+        self.sellingPriceAtMovement = 0.0
         self.referenceId = movement.referenceId
         self.notes = movement.notes
         self.movementDate = movement.createdAt


### PR DESCRIPTION
### Motivation
- The iOS `StockMovementDTO` encoded columns as `movement_type`/`movement_date` and omitted `purchase_price_at_movement`/`selling_price_at_movement`, which conflicts with the Supabase `stock_movements` table that expects `type`, `date` and requires the price fields (NOT NULL), causing remote inserts to be rejected and breaking sync.

### Description
- Update `iosApp/iosApp/Sync/SyncDTOs.swift` to map `movementType` to `type` and `movementDate` to `date` in the `CodingKeys` for `StockMovementDTO`.
- Add `purchasePriceAtMovement` and `sellingPriceAtMovement` properties to `StockMovementDTO`, map them to `purchase_price_at_movement` and `selling_price_at_movement`, and default them to `0.0` in the DTO initializer so inserts include the required non-null fields.

### Testing
- No automated tests were run for this change; the modification was committed and the updated file is `iosApp/iosApp/Sync/SyncDTOs.swift` and verified via local diff only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69714a2209dc8326a6127a6a210e0d4a)