### PR TITLE
Handle missing Supabase for iOS migrations and align StockMovementDTO with Supabase schema

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -59,6 +59,7 @@ struct ContentView: View {
     }
 
     private func runMigrationsIfNeeded() async {
+#if canImport(Supabase)
         guard SupabaseService.shared.isConfigured else {
             print("⚠️ Supabase non configuré - migrations ignorées")
             return
@@ -93,6 +94,9 @@ struct ContentView: View {
         } else {
             print("✅ Aucune nouvelle migration à appliquer")
         }
+#else
+        print("⚠️ Supabase indisponible - migrations ignorées")
+#endif
     }
 }
 

--- a/iosApp/iosApp/Services/MigrationManager.swift
+++ b/iosApp/iosApp/Services/MigrationManager.swift
@@ -1,4 +1,6 @@
 import Foundation
+
+#if canImport(Supabase)
 import Supabase
 
 /// Résultat de l'application d'une migration
@@ -302,6 +304,7 @@ class MigrationManager {
         )
     }
 }
+#endif
 
 // MARK: - String MD5 Extension
 

--- a/iosApp/iosApp/Sync/SyncDTOs.swift
+++ b/iosApp/iosApp/Sync/SyncDTOs.swift
@@ -528,6 +528,8 @@ struct StockMovementDTO: Codable {
     let siteId: String
     let quantity: Double
     let movementType: String
+    let purchasePriceAtMovement: Double
+    let sellingPriceAtMovement: Double
     let referenceId: String?
     let notes: String?
     let movementDate: Int64
@@ -540,10 +542,12 @@ struct StockMovementDTO: Codable {
         case productId = "product_id"
         case siteId = "site_id"
         case quantity
-        case movementType = "movement_type"
+        case movementType = "type"
+        case purchasePriceAtMovement = "purchase_price_at_movement"
+        case sellingPriceAtMovement = "selling_price_at_movement"
         case referenceId = "reference_id"
         case notes
-        case movementDate = "movement_date"
+        case movementDate = "date"
         case createdAt = "created_at"
         case createdBy = "created_by"
         case clientId = "client_id"
@@ -555,6 +559,8 @@ struct StockMovementDTO: Codable {
         self.siteId = movement.siteId
         self.quantity = movement.quantity
         self.movementType = movement.movementType
+        self.purchasePriceAtMovement = 0.0
+        self.sellingPriceAtMovement = 0.0
         self.referenceId = movement.referenceId
         self.notes = movement.notes
         self.movementDate = movement.createdAt


### PR DESCRIPTION
### Motivation
- Prevent runtime/build errors when the `Supabase` module is not available by avoiding references to `MigrationManager` in that configuration. 
- Ensure migration logic is skipped when Supabase is not configured at runtime so the app does not attempt DB operations when not set up. 
- Fix iOS-to-Supabase payload mismatches for stock movements so remote inserts are accepted by the `stock_movements` table.

### Description
- Wrap the whole migration implementation in `iosApp/iosApp/Services/MigrationManager.swift` with `#if canImport(Supabase)` so the type is only compiled when the `Supabase` module is present. 
- Guard `runMigrationsIfNeeded()` in `iosApp/iosApp/ContentView.swift` with `#if canImport(Supabase)` and print a fallback message when Supabase is unavailable, preventing use of `MigrationManager` in unsupported builds. 
- Update `iosApp/iosApp/Sync/SyncDTOs.swift` `StockMovementDTO` to map `movementType` -> `type` and `movementDate` -> `date`, add `purchasePriceAtMovement` and `sellingPriceAtMovement` mapped to `purchase_price_at_movement` and `selling_price_at_movement`, and default those price fields to `0.0` in the DTO initializer so required NOT NULL fields are included. 
- Small logging messages added to indicate when migrations are skipped due to missing configuration or missing Supabase support.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69714a2209dc8326a6127a6a210e0d4a)