### PR TITLE
Add MigrationManager stub when Supabase is unavailable and simplify migration flow

### DIFF
--- a/iosApp/iosApp/Services/MigrationManager.swift
+++ b/iosApp/iosApp/Services/MigrationManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Supabase
 
 /// Résultat de l'application d'une migration
 struct MigrationResult {
@@ -60,6 +59,9 @@ struct SchemaVersionDto: Codable {
         case updatedAt = "updated_at"
     }
 }
+
+#if canImport(Supabase)
+import Supabase
 
 /// Gestionnaire des migrations de schéma Supabase pour iOS
 ///
@@ -302,6 +304,28 @@ class MigrationManager {
         )
     }
 }
+#else
+class MigrationManager {
+    func checkCompatibility() async -> CompatibilityResult {
+        .unknown(reason: "Supabase indisponible")
+    }
+
+    func loadMigrationsFromBundle() -> [(name: String, sql: String, checksum: String)] {
+        []
+    }
+
+    func runPendingMigrations(appliedBy: String) async -> MigrationRunResult {
+        MigrationRunResult(
+            success: false,
+            migrationsApplied: [],
+            migrationsFailed: [],
+            migrationsSkipped: [],
+            systemNotInstalled: true,
+            errorMessage: "Supabase indisponible"
+        )
+    }
+}
+#endif
 
 // MARK: - String MD5 Extension
 

--- a/iosApp/iosApp/Sync/SyncDTOs.swift
+++ b/iosApp/iosApp/Sync/SyncDTOs.swift
@@ -528,6 +528,8 @@ struct StockMovementDTO: Codable {
     let siteId: String
     let quantity: Double
     let movementType: String
+    let purchasePriceAtMovement: Double
+    let sellingPriceAtMovement: Double
     let referenceId: String?
     let notes: String?
     let movementDate: Int64
@@ -540,10 +542,12 @@ struct StockMovementDTO: Codable {
         case productId = "product_id"
         case siteId = "site_id"
         case quantity
-        case movementType = "movement_type"
+        case movementType = "type"
+        case purchasePriceAtMovement = "purchase_price_at_movement"
+        case sellingPriceAtMovement = "selling_price_at_movement"
         case referenceId = "reference_id"
         case notes
-        case movementDate = "movement_date"
+        case movementDate = "date"
         case createdAt = "created_at"
         case createdBy = "created_by"
         case clientId = "client_id"
@@ -555,6 +559,8 @@ struct StockMovementDTO: Codable {
         self.siteId = movement.siteId
         self.quantity = movement.quantity
         self.movementType = movement.movementType
+        self.purchasePriceAtMovement = 0.0
+        self.sellingPriceAtMovement = 0.0
         self.referenceId = movement.referenceId
         self.notes = movement.notes
         self.movementDate = movement.createdAt


### PR DESCRIPTION
### Motivation
- Prevent build errors when the `Supabase` SDK is not present by ensuring `MigrationManager` and related DTO/enum types are always defined. 
- Keep the app from attempting DB migrations when Supabase is not configured at runtime by guarding migration execution. 
- Fix iOS↔Supabase payload mismatches for stock movements so remote inserts meet the `stock_movements` schema.

### Description
- Keep migration result types (`MigrationResult`, `MigrationRunResult`, `CompatibilityResult`, `SchemaMigrationDto`, `SchemaVersionDto`) outside conditional compilation so they are always available. 
- Move `import Supabase` and the full `MigrationManager` implementation under `#if canImport(Supabase)` and provide a lightweight stub `MigrationManager` under `#else` that returns safe default values and descriptive error messages. 
- Update `ContentView` to always instantiate `MigrationManager` (no conditional compilation) while retaining a runtime guard `SupabaseService.shared.isConfigured` to skip migrations when not configured. 
- Ensure `StockMovementDTO` field mappings align with Supabase column names by mapping `movementType` -> `type` and `movementDate` -> `date`, adding `purchasePriceAtMovement` and `sellingPriceAtMovement` fields with default `0.0` values to satisfy NOT NULL database columns (changes in `iosApp/iosApp/Sync/SyncDTOs.swift`).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69714a2209dc8326a6127a6a210e0d4a)