### PR TITLE
Add MigrationManager to iOS target, provide Supabase-conditional implementation, and fix StockMovement DTO mappings

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		A1SVC002BBBB000100000002 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SVC002BBBB000000000002 /* PermissionManager.swift */; };
 		A1SVC003BBBB000100000003 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SVC003BBBB000000000003 /* AuthService.swift */; };
 		A1SVC006BBBB000100000006 /* PasswordHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SVC006BBBB000000000006 /* PasswordHasher.swift */; };
+		A1SVC007BBBB000100000007 /* MigrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SVC007BBBB000000000007 /* MigrationManager.swift */; };
 		A1SYNC01CCCC000100000001 /* SyncQueueItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SYNC01CCCC000000000001 /* SyncQueueItem.swift */; };
 		A1SYNC02CCCC000100000002 /* SyncQueueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SYNC02CCCC000000000002 /* SyncQueueStore.swift */; };
 		A1SYNC03CCCC000100000003 /* SyncQueueHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SYNC03CCCC000000000003 /* SyncQueueHelper.swift */; };
@@ -100,6 +101,7 @@
 		A1SVC002BBBB000000000002 /* PermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
 		A1SVC003BBBB000000000003 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		A1SVC006BBBB000000000006 /* PasswordHasher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordHasher.swift; sourceTree = "<group>"; };
+		A1SVC007BBBB000000000007 /* MigrationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationManager.swift; sourceTree = "<group>"; };
 		A1SYNC01CCCC000000000001 /* SyncQueueItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncQueueItem.swift; sourceTree = "<group>"; };
 		A1SYNC02CCCC000000000002 /* SyncQueueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncQueueStore.swift; sourceTree = "<group>"; };
 		A1SYNC03CCCC000000000003 /* SyncQueueHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncQueueHelper.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				A1SVC002BBBB000000000002 /* PermissionManager.swift */,
 				A1SVC003BBBB000000000003 /* AuthService.swift */,
 				A1SVC006BBBB000000000006 /* PasswordHasher.swift */,
+				A1SVC007BBBB000000000007 /* MigrationManager.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -406,6 +409,7 @@
 				A1SVC003BBBB000100000003 /* AuthService.swift in Sources */,
 				A1000013AAAA000100000013 /* ProfileViews.swift in Sources */,
 				A1SVC006BBBB000100000006 /* PasswordHasher.swift in Sources */,
+				A1SVC007BBBB000100000007 /* MigrationManager.swift in Sources */,
 				A1SYNC01CCCC000100000001 /* SyncQueueItem.swift in Sources */,
 				A1SYNC02CCCC000100000002 /* SyncQueueStore.swift in Sources */,
 				A1SYNC03CCCC000100000003 /* SyncQueueHelper.swift in Sources */,

--- a/iosApp/iosApp/Services/MigrationManager.swift
+++ b/iosApp/iosApp/Services/MigrationManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Supabase
 
 /// Résultat de l'application d'une migration
 struct MigrationResult {
@@ -60,6 +59,9 @@ struct SchemaVersionDto: Codable {
         case updatedAt = "updated_at"
     }
 }
+
+#if canImport(Supabase)
+import Supabase
 
 /// Gestionnaire des migrations de schéma Supabase pour iOS
 ///
@@ -302,6 +304,28 @@ class MigrationManager {
         )
     }
 }
+#else
+class MigrationManager {
+    func checkCompatibility() async -> CompatibilityResult {
+        .unknown(reason: "Supabase indisponible")
+    }
+
+    func loadMigrationsFromBundle() -> [(name: String, sql: String, checksum: String)] {
+        []
+    }
+
+    func runPendingMigrations(appliedBy: String) async -> MigrationRunResult {
+        MigrationRunResult(
+            success: false,
+            migrationsApplied: [],
+            migrationsFailed: [],
+            migrationsSkipped: [],
+            systemNotInstalled: true,
+            errorMessage: "Supabase indisponible"
+        )
+    }
+}
+#endif
 
 // MARK: - String MD5 Extension
 

--- a/iosApp/iosApp/Sync/SyncDTOs.swift
+++ b/iosApp/iosApp/Sync/SyncDTOs.swift
@@ -528,6 +528,8 @@ struct StockMovementDTO: Codable {
     let siteId: String
     let quantity: Double
     let movementType: String
+    let purchasePriceAtMovement: Double
+    let sellingPriceAtMovement: Double
     let referenceId: String?
     let notes: String?
     let movementDate: Int64
@@ -540,10 +542,12 @@ struct StockMovementDTO: Codable {
         case productId = "product_id"
         case siteId = "site_id"
         case quantity
-        case movementType = "movement_type"
+        case movementType = "type"
+        case purchasePriceAtMovement = "purchase_price_at_movement"
+        case sellingPriceAtMovement = "selling_price_at_movement"
         case referenceId = "reference_id"
         case notes
-        case movementDate = "movement_date"
+        case movementDate = "date"
         case createdAt = "created_at"
         case createdBy = "created_by"
         case clientId = "client_id"
@@ -555,6 +559,8 @@ struct StockMovementDTO: Codable {
         self.siteId = movement.siteId
         self.quantity = movement.quantity
         self.movementType = movement.movementType
+        self.purchasePriceAtMovement = 0.0
+        self.sellingPriceAtMovement = 0.0
         self.referenceId = movement.referenceId
         self.notes = movement.notes
         self.movementDate = movement.createdAt


### PR DESCRIPTION
### Motivation
- Fix the build error where `ContentView` could not find `MigrationManager` by ensuring the source is part of the iOS target. 
- Make the migration flow robust when the `Supabase` SDK is not available at build/runtime by providing a safe fallback. 
- Ensure migration-related DTOs and result types remain available regardless of `Supabase` availability. 
- Align the `StockMovement` payload with the Supabase `stock_movements` columns and NOT NULL constraints.

### Description
- Added `MigrationManager.swift` to the iOS project file references, `Services` group, and the Sources build phase in `iosApp/iosApp.xcodeproj/project.pbxproj` so the file is compiled into the app. 
- Updated `iosApp/iosApp/Services/MigrationManager.swift` to move `import Supabase` and the full implementation under `#if canImport(Supabase)` while providing a lightweight `#else` stub `MigrationManager` that returns safe default values and descriptive error messages. 
- Kept the migration DTOs and enums (e.g. `MigrationResult`, `MigrationRunResult`, `CompatibilityResult`, `SchemaMigrationDto`, `SchemaVersionDto`) outside the conditional compilation so they are always defined. 
- Modified `iosApp/iosApp/Sync/SyncDTOs.swift` `StockMovementDTO` to map `movementType` -> `type` and `movementDate` -> `date`, and added `purchasePriceAtMovement` and `sellingPriceAtMovement` with default `0.0` to satisfy NOT NULL DB columns.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69714a2209dc8326a6127a6a210e0d4a)