### PR TITLE
Fix MigrationManager Supabase client access, add Supabase-conditional stub, and align StockMovement DTO

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		A1SVC002BBBB000100000002 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SVC002BBBB000000000002 /* PermissionManager.swift */; };
 		A1SVC003BBBB000100000003 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SVC003BBBB000000000003 /* AuthService.swift */; };
 		A1SVC006BBBB000100000006 /* PasswordHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SVC006BBBB000000000006 /* PasswordHasher.swift */; };
+		A1SVC007BBBB000100000007 /* MigrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SVC007BBBB000000000007 /* MigrationManager.swift */; };
 		A1SYNC01CCCC000100000001 /* SyncQueueItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SYNC01CCCC000000000001 /* SyncQueueItem.swift */; };
 		A1SYNC02CCCC000100000002 /* SyncQueueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SYNC02CCCC000000000002 /* SyncQueueStore.swift */; };
 		A1SYNC03CCCC000100000003 /* SyncQueueHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SYNC03CCCC000000000003 /* SyncQueueHelper.swift */; };
@@ -100,6 +101,7 @@
 		A1SVC002BBBB000000000002 /* PermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
 		A1SVC003BBBB000000000003 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		A1SVC006BBBB000000000006 /* PasswordHasher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordHasher.swift; sourceTree = "<group>"; };
+		A1SVC007BBBB000000000007 /* MigrationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationManager.swift; sourceTree = "<group>"; };
 		A1SYNC01CCCC000000000001 /* SyncQueueItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncQueueItem.swift; sourceTree = "<group>"; };
 		A1SYNC02CCCC000000000002 /* SyncQueueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncQueueStore.swift; sourceTree = "<group>"; };
 		A1SYNC03CCCC000000000003 /* SyncQueueHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncQueueHelper.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				A1SVC002BBBB000000000002 /* PermissionManager.swift */,
 				A1SVC003BBBB000000000003 /* AuthService.swift */,
 				A1SVC006BBBB000000000006 /* PasswordHasher.swift */,
+				A1SVC007BBBB000000000007 /* MigrationManager.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -406,6 +409,7 @@
 				A1SVC003BBBB000100000003 /* AuthService.swift in Sources */,
 				A1000013AAAA000100000013 /* ProfileViews.swift in Sources */,
 				A1SVC006BBBB000100000006 /* PasswordHasher.swift in Sources */,
+				A1SVC007BBBB000100000007 /* MigrationManager.swift in Sources */,
 				A1SYNC01CCCC000100000001 /* SyncQueueItem.swift in Sources */,
 				A1SYNC02CCCC000100000002 /* SyncQueueStore.swift in Sources */,
 				A1SYNC03CCCC000100000003 /* SyncQueueHelper.swift in Sources */,

--- a/iosApp/iosApp/Sync/SupabaseService.swift
+++ b/iosApp/iosApp/Sync/SupabaseService.swift
@@ -17,6 +17,10 @@ class SupabaseService {
         loadConfiguration()
     }
 
+    func currentClient() -> SupabaseClient? {
+        client
+    }
+
     // MARK: - Configuration
 
     func configure(url: String, anonKey: String) {

--- a/iosApp/iosApp/Sync/SyncDTOs.swift
+++ b/iosApp/iosApp/Sync/SyncDTOs.swift
@@ -528,6 +528,8 @@ struct StockMovementDTO: Codable {
     let siteId: String
     let quantity: Double
     let movementType: String
+    let purchasePriceAtMovement: Double
+    let sellingPriceAtMovement: Double
     let referenceId: String?
     let notes: String?
     let movementDate: Int64
@@ -540,10 +542,12 @@ struct StockMovementDTO: Codable {
         case productId = "product_id"
         case siteId = "site_id"
         case quantity
-        case movementType = "movement_type"
+        case movementType = "type"
+        case purchasePriceAtMovement = "purchase_price_at_movement"
+        case sellingPriceAtMovement = "selling_price_at_movement"
         case referenceId = "reference_id"
         case notes
-        case movementDate = "movement_date"
+        case movementDate = "date"
         case createdAt = "created_at"
         case createdBy = "created_by"
         case clientId = "client_id"
@@ -555,6 +559,8 @@ struct StockMovementDTO: Codable {
         self.siteId = movement.siteId
         self.quantity = movement.quantity
         self.movementType = movement.movementType
+        self.purchasePriceAtMovement = 0.0
+        self.sellingPriceAtMovement = 0.0
         self.referenceId = movement.referenceId
         self.notes = movement.notes
         self.movementDate = movement.createdAt


### PR DESCRIPTION
### Motivation
- Ensure `MigrationManager` can access the configured Supabase client without violating access control and avoid runtime crashes when Supabase is not available. 
- Provide a safe fallback implementation of migration handling when the `Supabase` SDK cannot be imported. 
- Align `StockMovement` sync DTO with the Supabase table column names and NOT NULL constraints so sync payloads match the DB schema. 

### Description
- Added a safe accessor `currentClient()` to `SupabaseService` to expose the configured `SupabaseClient` without changing the private `client` property. 
- Updated `MigrationManager` to use `SupabaseService.shared.currentClient()` in `init()` and `fatalError` with a clear message if no client is configured. 
- Wrapped the full `MigrationManager` implementation with `#if canImport(Supabase)` and added a lightweight `#else` stub class that returns safe defaults and descriptive error values. 
- Adjusted migration RPC response parsing to use `JSONSerialization.jsonObject(with: response.data)` directly and removed the incorrect optional binding on `response.data`. 
- Added `MigrationManager.swift` to the iOS target/project references so the file is included in the app build (`iosApp.xcodeproj` changes). 
- Updated `StockMovementDTO` in `SyncDTOs.swift` to map `movementType` -> `type` and `movementDate` -> `date`, and added `purchasePriceAtMovement` and `sellingPriceAtMovement` with default `0.0` to satisfy NOT NULL DB columns. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69714a2209dc8326a6127a6a210e0d4a)